### PR TITLE
Use zgrep to search /proc/config.gz

### DIFF
--- a/check-kernel.bash
+++ b/check-kernel.bash
@@ -22,14 +22,14 @@ if [ ! -e "$CONFIG" ]; then
 fi
 
 # Check if memory cgroups are enabled
-if grep -q 'CONFIG_MEMCG=y' "$CONFIG"; then
+if zgrep -q 'CONFIG_MEMCG=y' "$CONFIG"; then
     echo "Memory Limiting: Enabled"
 else
     echo "Memory Limiting: Disabled"
 fi
 
 # Check if cfs scheduling is enabled
-if grep -q 'CONFIG_FAIR_GROUP_SCHED=y' "$CONFIG"; then
+if zgrep -q 'CONFIG_FAIR_GROUP_SCHED=y' "$CONFIG"; then
     echo "CPU Limiting: Enabled"
 else
     echo "CPU Limiting: Disabled"


### PR DESCRIPTION
Using grep on `/proc/config.gz` fails, whereas zgrep should work on all of the files in `possibleConfigs` whether they're compressed or not.