### PR TITLE
Add user specific quotas

### DIFF
--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -97,7 +97,6 @@ class SystemdSpawner(Spawner):
 
         self.log.debug('user:%s Initialized spawner with unit %s', self.user.name, self.unit_name)
 
-
     def _expand_user_vars(self, string):
         """
         Expand user related variables in a given string

--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -1,9 +1,8 @@
 import os
 import pwd
-import time
 import subprocess
 import shlex
-from traitlets import Bool, Int, Unicode, List, Dict, Set
+from traitlets import Bool, Unicode, List, Dict, Set
 from tornado import gen
 
 from jupyterhub.spawner import Spawner


### PR DESCRIPTION
Hi,
I've added two configuration parameters:

-  `user_without_quotas `will overwrite mem_limit/cpu_limit. Users in this
list will have unlimited RAM and CPU.


- `special_user_quotas `will overwrite mem_limit and cpu_limit for a
specific user. It is possible to set mem_limit OR/AND cpu_limit.
```
user_without_quotas  = {'user1', 'user2'}
special_user_quotas = {
    'user3': {
        'mem_litmit': '2G'
    },
    'user4': {
        'mem_limit': '4G',
        'cpu_limit: 1.5
    }
}
```

user_without_quotas is **stronger** than special_user_quotas.

Hope it will be useful. 