### PR TITLE
fix faulty log string

### DIFF
--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -129,7 +129,7 @@ class SystemdSpawner(Spawner):
     @gen.coroutine
     def start(self):
         self.port = random_port()
-        self.log.debug('user:% Using port %s to start spawning for user %s', self.user.name, self.port)
+        self.log.debug('user:%s Using port %s to start spawning user server', self.user.name, self.port)
 
         # if a previous attempt to start the service for this user was made and failed,
         # systemd keeps the service around in 'failed' state. This will prevent future


### PR DESCRIPTION
The logging call contained a stray %-entry.
I kept the order of the arguments and moved the user token to the front while removing the extra %s in the end of the string. Also adjusted the message slightly.