### PR TITLE
Refactor & add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ The following features are currently available:
 9. Automatically collect logs from each individual user notebook into
    `journald`, which also handles log rotation.
 
+10. Dynamically allocate users with Systemd's [dynamic users](http://0pointer.net/blog/dynamic-users-with-systemd.html)
+    facility. Very useful in conjunction with [tmpauthenticator](https://github.com/jupyterhub/tmpauthenticator).
+
 ## Requirements ##
 
 ### Systemd ###
@@ -96,9 +99,15 @@ will explore hardening approaches soon.
 
 ### Local Users ###
 
-Each user's server is spawned to run as a local unix user account. Hence this spawner
+If running with `c.SystemdSpawner.dynamic_users = False` (the default), each user's
+server is spawned to run as a local unix user account. Hence this spawner
 requires that all users who authenticate have a local account already present on the
 machine.
+
+If running with `c.SystemdSpawner.dynamic_users = True`, no local user accounts
+are required. Systemd will automatically create dynamic users as required.
+See [this blog post](http://0pointer.net/blog/dynamic-users-with-systemd.html) for
+details.
 
 ### Linux Distro compatibility ##
 
@@ -152,6 +161,7 @@ in your `jupyterhub_config.py` file:
 - **[`disable_user_sudo`](#disable_user_sudo)**
 - **[`readonly_paths`](#readonly_paths)**
 - **[`readwrite_paths`](#readwrite_paths)**
+- **[`dynamic_users`](#dynamic_users)**
 
 ### `mem_limit` ###
 
@@ -353,6 +363,20 @@ Defaults to `None` which disables this feature.
 
 This requires systemd version > 228. If you enable this in earlier versions, spawning will
 fail. It can also contain only directories (not files) until systemd version 231.
+
+### `dynamic_users` ###
+
+Allocate system users dynamically for each user.
+
+Uses the DynamicUser= feature of Systemd to make a new system user
+for each hub user dynamically. Their home directories are set up
+under /var/lib/{USERNAME}, and persist over time. The system user
+is deallocated whenever the user's server is not running.
+
+See http://0pointer.net/blog/dynamic-users-with-systemd.html for more
+information.
+
+Requires systemd 235.
 
 ## Getting help ##
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ in your `jupyterhub_config.py` file:
 - **[`disable_user_sudo`](#disable_user_sudo)**
 - **[`readonly_paths`](#readonly_paths)**
 - **[`readwrite_paths`](#readwrite_paths)**
-- **[`use_sudo`](#use_sudo)**
 
 ### `mem_limit` ###
 
@@ -321,7 +320,8 @@ fail.
 List of filesystem paths that should be mounted readonly for the users' notebook server. This
 will override any filesystem permissions that might exist. Subpaths of paths that are mounted
 readonly can be marked readwrite with `readwrite_paths`. This is useful for marking `/` as
-readonly & only whitelisting the paths where notebook users can write.
+readonly & only whitelisting the paths where notebook users can write. If paths listed here
+do not exist, you will get an error.
 
 ```python
 c.SystemdSpawner.readonly_paths = ['/']
@@ -353,24 +353,6 @@ Defaults to `None` which disables this feature.
 
 This requires systemd version > 228. If you enable this in earlier versions, spawning will
 fail. It can also contain only directories (not files) until systemd version 231.
-
-### `use_sudo` ###
-
-Use sudo to run systemd-run / systemctl commands.
-
-This can be useful if you want to run jupyterhub as a non-root user. However,
-the utility of this is currently limited - you will need to give it pretty
-wide rights, and is not entirely useful. Eventually, we will make this
-more secure by splitting out the actual parts that require root into a
-separate script.
-
-It is still useful, however - things not running as root is always better
-than things running as root :)
-
-```python
-c.SystemdSpawner.use_sudo = False
-```
-Defaults to False.
 
 ## Getting help ##
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-asyncio

--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -1,0 +1,97 @@
+"""
+Systemd service utilities.
+
+Contains functions to start, stop & poll systemd services.
+Probably not very useful outside this spawner.
+"""
+import asyncio
+import shlex
+
+
+async def start_transient_service(
+    unit_name,
+    cmd,
+    args,
+    working_dir,
+    environment_variables=None,
+    properties=None,
+    uid=None,
+    gid=None,
+):
+    """
+    Start a systemd transient service with given paramters
+    """
+
+    run_cmd = [
+        'systemd-run',
+        '--unit', unit_name,
+    ]
+
+    if properties:
+        for key, value in properties.items():
+            if isinstance(value, list):
+                run_cmd += ['--property={}={}'.format(key, v) for v in value]
+            else:
+                # A string!
+                run_cmd.append('--property={}={}'.format(key, value))
+
+    if environment_variables:
+        run_cmd += [
+            '--setenv={}={}'.format(key, value)
+            for key, value in environment_variables.items()
+        ]
+
+    # Explicitly check if uid / gid are not None, since 0 is valid value for both
+    if uid is not None:
+        run_cmd += ['--uid', str(uid)]
+
+    if gid is not None:
+        run_cmd += ['--gid', str(gid)]
+
+    run_cmd.append('--property=WorkingDirectory={}'.format(shlex.quote(working_dir)))
+    # We unfortunately have to resort to doing cd with bash, since WorkingDirectory property
+    # of systemd units can't be set for transient units via systemd-run until systemd v227.
+    # Centos 7 has systemd 219, and will probably never upgrade - so we need to support them.
+    run_cmd += [
+        '/bin/bash',
+        '-c',
+        "cd {wd} && exec {cmd} {args}".format(
+            wd=shlex.quote(working_dir),
+            cmd=' '.join([shlex.quote(c) for c in cmd]),
+            args=' '.join([shlex.quote(a) for a in args])
+        )
+    ]
+
+    proc = await asyncio.create_subprocess_exec(*run_cmd)
+
+    return await proc.wait()
+
+
+async def service_running(unit_name):
+    """
+    Return true if service with given name is running (active).
+    """
+    proc = await asyncio.create_subprocess_exec(
+        'systemctl',
+        'is-active',
+        unit_name,
+        # hide stdout, but don't capture stderr at all
+        stdout=asyncio.subprocess.DEVNULL
+    )
+    ret = await proc.wait()
+
+    return ret == 0
+
+
+async def stop_service(unit_name):
+    """
+    Stop service with given name.
+
+    Throws CalledProcessError if stopping fails
+    """
+    proc = await asyncio.create_subprocess_exec(
+        'systemctl',
+        'stop',
+        unit_name
+    )
+    await proc.wait()

--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -111,7 +111,8 @@ class SystemdSpawner(Spawner):
 
         Uses the DynamicUser= feature of Systemd to make a new system user
         for each hub user dynamically. Their home directories are set up
-        under /var/lib/{USERNAME}, and persist over time.
+        under /var/lib/{USERNAME}, and persist over time. The system user
+        is deallocated whenever the user's server is not running.
 
         See http://0pointer.net/blog/dynamic-users-with-systemd.html for more
         information.

--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -1,9 +1,10 @@
 import os
 import pwd
 import subprocess
-import shlex
-from traitlets import Bool, Unicode, List
-from tornado import gen
+from traitlets import Bool, Unicode, List, Dict
+import asyncio
+
+from systemdspawner import systemd
 
 from jupyterhub.spawner import Spawner
 from jupyterhub.utils import random_port
@@ -87,25 +88,19 @@ class SystemdSpawner(Spawner):
         """,
     ).tag(config=True)
 
-    unit_extra_properties = List(
-        None,
-        allow_none=True,
+    unit_extra_properties = Dict(
+        {},
         help="""
-        List of extra properties for systemd-run --property=[...].
+        Dict of extra properties for systemd-run --property=[...].
+
+        Keys are property names, and values are either strings or
+        list of strings (for multiple entries). When values are
+        lists, ordering is guaranteed. Ordering across keys of the
+        dictionary are *not* guaranteed.
 
         Used to add arbitrary properties for spawned Jupyter units.
-        Read `man systemd-run` for details on per-unit properties.
-        """
-    ).tag(config=True)
-
-    use_sudo = Bool(
-        False,
-        help="""
-        Use sudo to run systemd-run / systemctl commands.
-
-        Partially useful when running JupyterHub as a non-root user but with
-        full sudo control. Partially protects against a large class of attacks
-        (except full Remote Code Execution in JupyterHub).
+        Read `man systemd-run` for details on per-unit properties
+        available in transient units.
         """
     ).tag(config=True)
 
@@ -128,12 +123,6 @@ class SystemdSpawner(Spawner):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # All traitlets configurables are configured by now
-        self.systemctl_cmd = ['/bin/systemctl']
-        self.systemd_run_cmd = ['/usr/bin/systemd-run']
-        if self.use_sudo:
-            self.systemctl_cmd.insert(0, '/usr/bin/sudo')
-            self.systemd_run_cmd.insert(0, '/usr/bin/sudo')
-
         self.unit_name = self._expand_user_vars(self.unit_name_template)
 
         self.log.debug('user:%s Initialized spawner with unit %s', self.user.name, self.unit_name)
@@ -180,81 +169,49 @@ class SystemdSpawner(Spawner):
         if 'unit_name' in state:
             self.unit_name = state['unit_name']
 
-    @gen.coroutine
-    def start(self):
+    async def start(self):
         self.port = random_port()
         self.log.debug('user:%s Using port %s to start spawning user server', self.user.name, self.port)
 
-        # if a previous attempt to start the service for this user was made and failed,
-        # systemd keeps the service around in 'failed' state. This will prevent future
-        # services with the same name from being started. While this behavior makes sense
-        # (since if it fails & is deleted immediately, we will lose state info), in our
-        # case it is ok to reset it and move on when trying to start again.
-        try:
-            if subprocess.check_output(self.systemctl_cmd + [
-                'is-failed',
-                self.unit_name
-            ]).decode('utf-8').strip() == 'failed':
-                subprocess.check_output(self.systemctl_cmd + [
-                    'reset-failed',
-                    self.unit_name
-                ])
-                self.log.info('user:%s Unit %s in failed state, resetting', self.user.name, self.unit_name)
-        except subprocess.CalledProcessError as e:
-            # This is returned when the unit is *not* in failed state. bah!
-            pass
-
         # If there's a unit with this name running already. This means a bug in
-        # JupyterHub, or a remnant from a previous install of JupyterHub.
-        # Regardless, we kill it and start ours in its place.
+        # JupyterHub, a remnant from a previous install or a failed service start
+        # from earlier. Regardless, we kill it and start ours in its place.
         # FIXME: Carefully look at this when doing a security sweep.
-        already_active = False
-        try:
-            if subprocess.check_output(self.systemctl_cmd + [
-                'is-active',
-                self.unit_name
-            ]).decode('utf-8').strip() == 'active':
-                already_active = True
-        except subprocess.CalledProcessError:
-            # If unit is not already active we get this exception. Can ignore.
-            pass
-
-        if already_active:
-            # If the unit *is* already active, we must stop it.
-            # Exception here should just bubble up.
-            subprocess.check_output(self.systemctl_cmd + [
-                'stop',
-                self.unit_name
-            ])
+        if await systemd.service_running(self.unit_name):
+            await systemd.stop(self.unit_name)
             self.log.info('user:%s Unit %s already exists but not known to JupyterHub. Killing', self.user.name, self.unit_name)
+            if await systemd.service_running(self.unit_name):
+                self.log.error('user:%s Could not stop already existing unit %s', self.user.name, self.unit_name)
+                raise Exception('Could not stop already existing unit {}'.format(self.unit_name))
 
         env = self.get_env()
 
-        cmd = self.systemd_run_cmd[:]
+        properties = {}
 
-        cmd.extend(['--unit', self.unit_name])
         if self.dynamic_users:
-            cmd.extend([
-                '--property=DynamicUser=yes',
-                self._expand_user_vars('--property=StateDirectory={USERNAME}')
-            ])
+            properties['DynamicUser'] = 'yes'
+            properties['StateDirectory'] = self._expand_user_vars('{USERNAME}')
+
             # HOME is not set by default otherwise
             env['HOME'] = self._expand_user_vars('/var/lib/{USERNAME}')
             # Set working directory to $HOME too
             self.user_workingdir = env['HOME']
+            # Set uid, gid = None so we don't set them
+            uid = gid = None
         else:
             try:
                 pwnam = pwd.getpwnam(self.user.name)
             except KeyError:
                 self.log.exception('No user named %s found in the system' % self.user.name)
                 raise
-            cmd.extend(['--uid', str(pwnam.pw_uid), '--gid', str(pwnam.pw_gid)])
+            uid = pwnam.pw_uid
+            gid = pwnam.pw_gid
 
         if self.isolate_tmp:
-            cmd.extend(['--property=PrivateTmp=yes'])
+            properties['PrivateTmp'] = 'yes'
 
         if self.isolate_devices:
-            cmd.extend(['--property=PrivateDevices=yes'])
+            properties['PrivateDevices'] = 'yes'
 
         if self.extra_paths:
             env['PATH'] = '{extrapath}:{curpath}'.format(
@@ -264,89 +221,60 @@ class SystemdSpawner(Spawner):
                 )
             )
 
-        for key, value in env.items():
-            cmd.append('--setenv={key}={value}'.format(key=key, value=value))
-
-        cmd.append('--setenv=SHELL={shell}'.format(shell=self.default_shell))
+        env['SHELL'] = self.default_shell
 
         if self.mem_limit is not None:
             # FIXME: Detect & use proper properties for v1 vs v2 cgroups
-            cmd.extend([
-                '--property=MemoryAccounting=yes',
-                '--property=MemoryLimit={mem}'.format(mem=self.mem_limit),
-            ])
+            properties['MemoryAccounting'] = 'yes'
+            properties['MemoryLimit'] = self.mem_limit
 
         if self.cpu_limit is not None:
             # FIXME: Detect & use proper properties for v1 vs v2 cgroups
             # FIXME: Make sure that the kernel supports CONFIG_CFS_BANDWIDTH
             #        otherwise this doesn't have any effect.
-            cmd.extend([
-                '--property=CPUAccounting=yes',
-                '--property=CPUQuota={quota}%'.format(quota=int(self.cpu_limit * 100))
-            ])
+            properties['CPUAccounting'] = 'yes'
+            properties['CPUQuota'] = '{}%'.format(int(self.cpu_limit * 100))
 
         if self.disable_user_sudo:
-            cmd.append('--property=NoNewPrivileges=yes')
+            properties['NoNewPrivileges'] = 'yes'
 
         if self.readonly_paths is not None:
-            cmd.extend([
-                self._expand_user_vars('--property=ReadOnlyDirectories=-{path}'.format(path=path))
+            properties['ReadOnlyDirectories'] = [
+                self._expand_user_vars(path)
                 for path in self.readonly_paths
-            ])
+            ]
 
         if self.readwrite_paths is not None:
-            cmd.extend([
-                self._expand_user_vars('--property=ReadWriteDirectories={path}'.format(path=path))
+            properties['ReadWriteDirectories'] = [
+                self._expand_user_vars(path)
                 for path in self.readwrite_paths
-            ])
+            ]
 
-        if self.unit_extra_properties is not None:
-            cmd.extend([
-                self._expand_user_vars('--property={prop}'.format(prop=prop))
-                for prop in self.unit_extra_properties
-            ])
+        properties.update(self.unit_extra_properties)
 
-        # We unfortunately have to resort to doing cd with bash, since WorkingDirectory property
-        # of systemd units can't be set for transient units via systemd-run until systemd v227.
-        # Centos 7 has systemd 219, and will probably never upgrade - so we need to support them.
-        bash_cmd = [
-            '/bin/bash',
-            '-c',
-            "cd {wd} && exec {cmd} {args}".format(
-                wd=shlex.quote(self._expand_user_vars(self.user_workingdir)),
-                cmd=' '.join([shlex.quote(self._expand_user_vars(c)) for c in self.cmd]),
-                args=' '.join([shlex.quote(a) for a in self.get_args()])
-            )
-        ]
-        cmd.extend(bash_cmd)
-
-        self.log.debug('user:%s Running systemd-run with: %s', self.user.name, ' '.join(cmd))
-        subprocess.check_output(cmd)
+        await systemd.start_transient_service(
+            self.unit_name,
+            cmd=[self._expand_user_vars(c) for c in self.cmd],
+            args=[self._expand_user_vars(a) for a in self.get_args()],
+            working_dir=self._expand_user_vars(self.user_workingdir),
+            environment_variables=env,
+            properties=properties,
+            uid=uid,
+            gid=gid
+        )
 
         for i in range(self.start_timeout):
-            is_up = yield self.poll()
+            is_up = await self.poll()
             if is_up is None:
                 return (self.ip or '127.0.0.1', self.port)
-            yield gen.sleep(1)
+            await asyncio.sleep(1)
 
         return None
 
-    @gen.coroutine
-    def stop(self, now=False):
-        subprocess.check_output(self.systemctl_cmd + [
-            'stop',
-            self.unit_name
-        ])
+    async def stop(self, now=False):
+        await systemd.stop_service(self.unit_name)
 
-    @gen.coroutine
-    def poll(self):
-        try:
-            if subprocess.check_call(self.systemctl_cmd + [
-                'is-active',
-                self.unit_name
-            ], stdout=open('/dev/null', 'w'), stderr=open('/dev/null', 'w')) == 0:
-                self.log.debug('user:%s unit %s is active', self.user.name, self.unit_name)
-                return None
-        except subprocess.CalledProcessError as e:
-            self.log.debug('user:%s unit %s is not active', self.user.name, self.unit_name)
-            return e.returncode
+    async def poll(self):
+        if await systemd.service_running(self.unit_name):
+            return None
+        return 1

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -1,0 +1,181 @@
+"""
+Test systemd wrapper utilities.
+
+Must run as root.
+"""
+import tempfile
+from systemdspawner import systemd
+import pytest
+import asyncio
+import os
+import time
+
+
+@pytest.mark.asyncio
+async def test_simple_start():
+    unit_name = 'systemdspawner-unittest-' + str(time.time())
+    await systemd.start_transient_service(
+        unit_name,
+        ['sleep'],
+        ['2000'],
+        working_dir='/'
+    )
+
+    assert await systemd.service_running(unit_name)
+
+    await systemd.stop_service(unit_name)
+
+    assert not await systemd.service_running(unit_name)
+
+
+@pytest.mark.asyncio
+async def test_service_running_fail():
+    """
+    Test service_running failing when there's no service.
+    """
+    unit_name = 'systemdspawner-unittest-' + str(time.time())
+
+    assert not await systemd.service_running(unit_name)
+
+
+@pytest.mark.asyncio
+async def test_env_setting():
+    unit_name = 'systemdspawner-unittest-' + str(time.time())
+    with tempfile.TemporaryDirectory() as d:
+        await systemd.start_transient_service(
+            unit_name,
+            ['/bin/bash'],
+            ['-c', 'env > {}/env'.format(d)],
+            working_dir='/',
+            environment_variables={
+                'TESTING_SYSTEMD_ENV_1': 'TEST_1',
+                'TESTING_SYSTEMD_ENV_2': 'TEST_2'
+            }
+        )
+
+        # Wait a tiny bit for the systemd unit to complete running
+        await asyncio.sleep(0.1)
+        with open(os.path.join(d, 'env')) as f:
+            text = f.read()
+            assert 'TESTING_SYSTEMD_ENV_1=TEST_1' in text
+            assert 'TESTING_SYSTEMD_ENV_2=TEST_2' in text
+
+
+@pytest.mark.asyncio
+async def test_workdir():
+    unit_name = 'systemdspawner-unittest-' + str(time.time())
+    _, env_filename = tempfile.mkstemp()
+    with tempfile.TemporaryDirectory() as d:
+        await systemd.start_transient_service(
+            unit_name,
+            ['/bin/bash'],
+            ['-c', 'pwd > {}/pwd'.format(d)],
+            working_dir=d,
+        )
+
+        # Wait a tiny bit for the systemd unit to complete running
+        await asyncio.sleep(0.1)
+        with open(os.path.join(d, 'pwd')) as f:
+            text = f.read().strip()
+            assert text == d
+
+
+@pytest.mark.asyncio
+async def test_properties_string():
+    """
+    Test that setting string properties works
+
+    - Make a temporary directory
+    - Bind mount temporary directory to /bind-test
+    - Start process in /bind-test, write to current-directory/pwd the working directory
+    - Read it from the *temporary* directory, verify it is /bind-test
+
+    This validates the Bind Mount is working, and hence properties are working.
+    """
+    unit_name = 'systemdspawner-unittest-' + str(time.time())
+    _, env_filename = tempfile.mkstemp()
+    with tempfile.TemporaryDirectory() as d:
+        await systemd.start_transient_service(
+            unit_name,
+            ['/bin/bash'],
+            ['-c', 'pwd > pwd'.format(d)],
+            working_dir='/bind-test',
+            properties={
+                'BindPaths': '{}:/bind-test'.format(d)
+            }
+        )
+
+        # Wait a tiny bit for the systemd unit to complete running
+        await asyncio.sleep(0.1)
+        with open(os.path.join(d, 'pwd')) as f:
+            text = f.read().strip()
+            assert text == '/bind-test'
+
+
+@pytest.mark.asyncio
+async def test_properties_list():
+    """
+    Test setting multiple values for a property
+
+    - Make a temporary directory
+    - Before starting process, run two mkdir commands to create a nested
+      directory. These commands must be run in order by systemd, otherewise
+      they will fail. This validates that ordering behavior is preserved.
+    - Start a process in temporary directory
+    - Write current directory to nested directory created in ExecPreStart
+
+    This validates multiple ordered ExcePreStart calls are working, and hence
+    properties with lists as values are working.
+    """
+    unit_name = 'systemdspawner-unittest-' + str(time.time())
+    _, env_filename = tempfile.mkstemp()
+    with tempfile.TemporaryDirectory() as d:
+        await systemd.start_transient_service(
+            unit_name,
+            ['/bin/bash'],
+            ['-c', 'pwd > test-1/test-2/pwd'],
+            working_dir=d,
+            properties={
+                'ExecStartPre': [
+                    '/bin/mkdir test-1',
+                    '/bin/mkdir test-1/test-2'
+                ],
+            }
+        )
+
+        # Wait a tiny bit for the systemd unit to complete running
+        await asyncio.sleep(0.1)
+        with open(os.path.join(d, 'test-1', 'test-2', 'pwd')) as f:
+            text = f.read().strip()
+            assert text == d
+
+
+@pytest.mark.asyncio
+async def test_uid_gid():
+    """
+    Test setting uid and gid
+
+    - Make a temporary directory
+    - Run service as uid 65534 (nobody) and gid 0 (root)
+    - Verify the output of the 'id' command
+
+    This validates that setting uid sets uid, gid sets the gid
+    """
+    unit_name = 'systemdspawner-unittest-' + str(time.time())
+    _, env_filename = tempfile.mkstemp()
+    with tempfile.TemporaryDirectory() as d:
+        os.chmod(d, 0o777)
+        await systemd.start_transient_service(
+            unit_name,
+            ['/bin/bash'],
+            ['-c', 'id > id'],
+            working_dir=d,
+            uid=65534,
+            gid=0
+        )
+
+        # Wait a tiny bit for the systemd unit to complete running
+        await asyncio.sleep(0.2)
+        with open(os.path.join(d, 'id')) as f:
+            text = f.read().strip()
+            assert text == 'uid=65534(nobody) gid=0(root) groups=0(root)'


### PR DESCRIPTION
- Use async/await syntax, require Python 3.5
- Separate systemd related calls into own file
- Add unit tests for systemd related calls
- Use asyncio process rather than blocking subprocess calls.
  This also makes us use Tornado 5.0+
- Switch unit_extra_properties to be a Dict rather than List.
  This is more flexible. It's a breaking change, but the release
  with unit_extra_properties is so new this is ok.
- ReadOnlyPaths no longer prepends a '-' in front of the paths.
  This was an oversight earlier. This means units will fail
  if there's a path there that does not exist.
- use_sudo is no longer supported. It offered questionable security.
  JupyterHub services should be secured with other mechanisms instead.
  If we really want to support sudo, we can do so at a later time.