### PR TITLE
Nonroot

### DIFF
--- a/jupyter-singleuser@.service
+++ b/jupyter-singleuser@.service
@@ -25,3 +25,4 @@ CPUQuota=400%
 MemoryAccounting=yes
 MemoryHigh=8G
 MemoryMax=9G
+PAMName=%i

--- a/jupyter-singleuser@.service
+++ b/jupyter-singleuser@.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Jupyterhub Single-User Server for user %i
+Wants=jupyterhub.service
+
+[Service]
+Type=simple
+User=%i
+EnvironmentFile=/srv/jupyterhub/envs/%i.env
+ExecStart=<path to single server executable> $USERINSTANCEARGS
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectSystem=strict
+ProtectHome=read-only
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+# if your WorkingDirectory is on NFS and you use systemd <= 239 setting
+# WorkingDirectory will not work, and you will have to use
+# ExecStart=/bin/bash -c "cd <your workdir> && <path to single server executable> $USERINSTANCEARGS"
+# and comment out WorkingDirectory
+WorkingDirectory=~
+ReadWritePaths=/home/%i
+NoNewPrivileges=yes
+CPUAccounting=yes
+CPUQuota=400%
+MemoryAccounting=yes
+MemoryHigh=8G
+MemoryMax=9G

--- a/systemdspawner/__init__.py
+++ b/systemdspawner/__init__.py
@@ -1,3 +1,4 @@
 from systemdspawner.systemdspawner import SystemdSpawner
+from systemdspawner.nontransientspawner import SystemdNonTransientSpawner
 
-__all__ = [SystemdSpawner]
+__all__ = [SystemdSpawner, SystemdNonTransientSpawner]

--- a/systemdspawner/nontransientspawner.py
+++ b/systemdspawner/nontransientspawner.py
@@ -1,0 +1,162 @@
+import os
+import pwd
+import subprocess
+from traitlets import Bool, Unicode, List, Dict
+import asyncio
+import shlex
+
+from systemdspawner import systemd
+
+from jupyterhub.spawner import Spawner
+from jupyterhub.utils import random_port
+
+
+class SystemdNonTransientSpawner(Spawner):
+    unit_template = Unicode(
+        'jupyter-singleuser@{USERNAME}.service',
+        help="""
+        Name of the systemd service template including templated part.
+
+        {USERNAME} and {USERID} are expanded.
+        """
+    ).tag(config=True)
+
+    envfile_template = Unicode(
+        '/srv/jupyterhub/envs/{USERNAME}.env',
+        help="""
+        Path of the environment file for a single user server.
+
+        {USERNAME} and {USERID} are expanded.
+        """
+    )
+
+    use_sudo = Bool(
+        False,
+        help="""
+        Use sudo to start and stop systemd services.
+
+        If set to False, sudo will not be used and you will have to a policykit
+        rule to allow the Jupyterhub user to start and stop the singleuser server
+        services. This requires policykitversion larger than 105, which are not
+        available in Debian or Ubuntu and its derivatives.
+        """
+    ).tag(config=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # All traitlets configurables are configured by now
+        self.unit_name = self._expand_user_vars(self.unit_template)
+        self.envfilepath = self._expand_user_vars(self.envfile_template)
+
+        self.log.debug('user:%s Initialized spawner with unit %s', self.user.name, self.unit_name)
+
+    def _expand_user_vars(self, string):
+        """
+        Expand user related variables in a given string
+
+        Currently expands:
+          {USERNAME} -> Name of the user
+          {USERID} -> UserID
+        """
+        return string.format(
+            USERNAME=self.user.name,
+            USERID=self.user.id
+        )
+
+    def get_state(self):
+        """
+        Save state required to reconstruct spawner from scratch
+
+        We save the unit name, just in case the unit template was changed
+        between a restart. We do not want to lost the previously launched
+        events.
+
+        JupyterHub before 0.7 also assumed your notebook was dead if it
+        saved no state, so this helps with that too!
+        """
+        state = super().get_state()
+        state['unit_name'] = self.unit_name
+        return state
+
+    def load_state(self, state):
+        """
+        Load state from storage required to reinstate this user's server
+
+        This runs after __init__, so we can override it with saved unit name
+        if needed. This is useful primarily when you change the unit name template
+        between restarts.
+
+        JupyterHub before 0.7 also assumed your notebook was dead if it
+        saved no state, so this helps with that too!
+        """
+        if 'unit_name' in state:
+            self.unit_name = state['unit_name']
+
+        if self.unit_name != self._expand_user_vars(self.unit_template):
+            self.log.debug("Trying to reinstate an outdated unit name that does not match unit_template!")
+
+    def _set_envfile_acl(self):
+        acl = self._expand_user_vars("u:{USERNAME}:rw")
+        self.log.debug("Setting ACL %s on %s", acl, self.envfilepath)
+        subprocess.run(['setfacl', '-m', acl, self.envfilepath], check=True)
+
+    async def start(self):
+        self.port = random_port()
+        self.log.debug('user:%s Using port %s to start spawning user server', self.user.name, self.port)
+
+        # If there's a unit with this name running already. This means a bug in
+        # JupyterHub, a remnant from a previous install or a failed service start
+        # from earlier. Regardless, we kill it and start ours in its place.
+        # FIXME: Carefully look at this when doing a security sweep.
+        if await systemd.service_running(self.unit_name):
+            await systemd.stop_service(self.unit_name, self.use_sudo)
+            self.log.info('user:%s Unit %s already exists but not known to JupyterHub. Killing', self.user.name, self.unit_name)
+            if await systemd.service_running(self.unit_name):
+                self.log.error('user:%s Could not stop already existing unit %s', self.user.name, self.unit_name)
+                raise Exception('Could not stop already existing unit {}'.format(self.unit_name))
+
+        # If there's a unit with this name already but sitting in a failed state.
+        # Does a reset of the state before trying to start it up again.
+        if await systemd.service_failed(self.unit_name):
+            self.log.info('user:%s Unit %s in a failed state. Resetting state.', self.user.name, self.unit_name)
+            await systemd.reset_service(self.unit_name, self.use_sudo)
+
+        env = self.get_env()
+        env['USERINSTANCEARGS'] = ' '.join([shlex.quote(self._expand_user_vars(a)) for a in self.get_args()])
+
+        self.log.debug('writing user server environment file %s', self.envfilepath)
+        with open(self.envfilepath, 'w') as envfile:
+            os.chmod(self.envfilepath, 0o600)
+            envfile.writelines(
+                '\n'.join('{k}={v}'.format(k=k, v=v) for k, v in env.items())
+            )
+        self._set_envfile_acl()
+
+        if self.use_sudo:
+            sudo_cmd = 'sudo '
+        else:
+            sudo_cmd = ''
+
+        self.log.debug('running %ssystemctl start %s', sudo_cmd, self.unit_name)
+        ret = await systemd.start_service(self.unit_name, self.use_sudo)
+        self.log.debug('%ssystemctl start %s returned with %s', sudo_cmd, self.unit_name, ret)
+
+        for i in range(self.start_timeout):
+            is_up = await self.poll()
+            if is_up is None:
+                self.log.debug('systemctl is-active %s: %s', self.unit_name, bool(is_up))
+                self.log.debug('returning now, the rest is out of my hands')
+                return (self.ip or '127.0.0.1', self.port)
+            await asyncio.sleep(1)
+
+        self.log.debug('systemctl is-active %s: %s', self.unit_name, bool(is_up))
+        return None
+
+    async def stop(self, now=False):
+        await systemd.stop_service(self.unit_name, self.use_sudo)
+        os.remove(self.envfilepath)
+
+    async def poll(self):
+        if await systemd.service_running(self.unit_name):
+            return None
+        return 1

--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -103,29 +103,40 @@ async def service_failed(unit_name):
     return ret == 0
 
 
-async def stop_service(unit_name):
+async def stop_service(unit_name, sudo=False):
     """
     Stop service with given name.
 
     Throws CalledProcessError if stopping fails
     """
-    proc = await asyncio.create_subprocess_exec(
-        'systemctl',
-        'stop',
-        unit_name
-    )
-    await proc.wait()
+    cmd = ['systemctl', 'stop', unit_name]
+    if sudo:
+        cmd = ['sudo', '--non-interactive'] + cmd
+    proc = await asyncio.create_subprocess_exec(*cmd)
+    return await proc.wait()
 
 
-async def reset_service(unit_name):
+async def reset_service(unit_name, sudo=False):
     """
     Reset service with given name.
 
     Throws CalledProcessError if resetting fails
     """
-    proc = await asyncio.create_subprocess_exec(
-        'systemctl',
-        'reset-failed',
-        unit_name
-    )
+    cmd = ['systemctl', 'reset-failed', unit_name]
+    if sudo:
+        cmd = ['sudo', '--non-interactive'] + cmd
+    proc = await asyncio.create_subprocess_exec(cmd)
     await proc.wait()
+
+
+async def start_service(unit_name, sudo=False):
+    """
+    Start service with given name.
+
+    Throws CalledProcessError if starting fails
+    """
+    cmd = ['systemctl', 'start', unit_name]
+    if sudo:
+        cmd = ['sudo', '--non-interactive'] + cmd
+    proc = await asyncio.create_subprocess_exec(*cmd)
+    return await proc.wait()


### PR DESCRIPTION
Hi,

thanks a lot for this spawner, here are a couple of additions I made this week and that I'd like to share.

I wasn't too happy to have the jupyterhub run as root, so this adds a spawner that relies on service files that are installed on the system. This obviates the need for most of the config that `SystemdSpawner` has, since those options move to the service file.

The jupyterhub service runs as system user jupyter (or whatever you configure) and can either start the user instances via sudo, which needs a rule along the lines of
```
Cmnd_Alias JUPYTERSTART = /usr/bin/systemctl start jupyter-singleuser@[[\:alpha\:]]?[[\:alnum\:]]*.service
Cmnd_Alias JUPYTERSTOP = /usr/bin/systemctl stop jupyter-singleuser@[[\:alpha\:]]?[[\:alnum\:]]*.service
Cmnd_Alias JUPYTERRESET = /usr/bin/systemctl reset-failed jupyter-singleuser@[[\:alpha\:]]?[[\:alnum\:]]*.service
Defaults!JUPTERSTART !requiretty
Defaults!JUPTERSTOP !requiretty
Defaults!JUPTERRESET !requiretty
jupyter HOST = (root) NOPASSWD: JUPYTERSTART
jupyter HOST = (root) NOPASSWD: JUPYTERSTOP
jupyter HOST = (root) NOPASSWD: JUPYTERRESET
```
or plain systemctl using a policykit rule that could look like this
```javascript
polkit.addRule(function(action, subject) {
    if (action.id == "org.freedesktop.systemd1.manage-units") {
        if (action.lookup("unit").match(/^jupyter-singleuser@[a-zA-Z]?\w*.service$/)) {
            var verb = action.lookup("verb");
            if ((verb == "start" || 
                 verb == "stop" || 
                 verb == "reset-failed") && 
                subject.user == "jupyter") {
                return polkit.Result.YES;
            }
        }
    }
});
```

I have tested both cases, but the latter requires a policykit version of 106 or later and Debian (and its derivatives like Ubuntu) only ship a heavily patched policykit 105 and require the sudo way. The sudo way also precludes the use of `NoNewPriviliges` for the jupyterhub service.

To get the arguments from the jupyterhub server to the single user instances, I use an environment file. Since it contains sensitive information and therefore cannot be world readable, I use ACLs to make it readable for the user of the instance, since only root can chown.

So far I've tested this on Debian Sid (unstable), were it works fine, but it lacks documentation and is still geared towards my use case.

So, what needs to be done to get this upstreamed (if there is interested from your side)? :)