### PR TITLE
Check state of service before startup and reset if failed

### DIFF
--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -83,6 +83,22 @@ async def service_running(unit_name):
     return ret == 0
 
 
+async def service_failed(unit_name):
+    """
+    Return true if service with given name is in a failed state.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        'systemctl',
+        'is-failed',
+        unit_name,
+        # hide stdout, but don't capture stderr at all
+        stdout=asyncio.subprocess.DEVNULL
+    )
+    ret = await proc.wait()
+
+    return ret == 0
+
+
 async def stop_service(unit_name):
     """
     Stop service with given name.
@@ -92,6 +108,20 @@ async def stop_service(unit_name):
     proc = await asyncio.create_subprocess_exec(
         'systemctl',
         'stop',
+        unit_name
+    )
+    await proc.wait()
+
+
+async def reset_service(unit_name):
+    """
+    Reset service with given name.
+
+    Throws CalledProcessError if resetting fails
+    """
+    proc = await asyncio.create_subprocess_exec(
+        'systemctl',
+        'reset-failed',
         unit_name
     )
     await proc.wait()

--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -201,6 +201,12 @@ class SystemdSpawner(Spawner):
                 self.log.error('user:%s Could not stop already existing unit %s', self.user.name, self.unit_name)
                 raise Exception('Could not stop already existing unit {}'.format(self.unit_name))
 
+        # If there's a unit with this name already but sitting in a failed state.
+        # Does a reset of the state before trying to start it up again.
+        if await systemd.service_failed(self.unit_name):
+            self.log.info('user:%s Unit %s in a failed state. Resetting state.', self.user.name, self.unit_name)
+            await systemd.reset_service(self.unit_name)
+
         env = self.get_env()
 
         properties = {}

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -29,6 +29,30 @@ async def test_simple_start():
 
 
 @pytest.mark.asyncio
+async def test_service_failed_reset():
+    """
+    Test service_failed and reset_service
+    """
+    unit_name = 'systemdspawner-unittest-' + str(time.time())
+    # Running a service with an invalid UID makes it enter a failed state
+    await systemd.start_transient_service(
+        unit_name,
+        ['sleep'],
+        ['2000'],
+        uid='systemdspawner-unittest-does-not-exist',
+        working_dir='/'
+    )
+
+    await asyncio.sleep(0.1)
+
+    assert await systemd.service_failed(unit_name)
+
+    await systemd.reset_service(unit_name)
+
+    assert not await systemd.service_failed(unit_name)
+
+
+@pytest.mark.asyncio
 async def test_service_running_fail():
     """
     Test service_running failing when there's no service.


### PR DESCRIPTION
If a user's service enters a failed state, the spawner can never recover until the state is reset manually on the host. This change will have the spawner check the state before it tries to spin up a new instance and if the state is failed, will attempt to reset it.

FIXES #44 