### PR TITLE
Fix unit-test for service_failed to work on systemd>229

### DIFF
--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -39,8 +39,7 @@ async def test_service_failed_reset():
         unit_name,
         ['sleep'],
         ['2000'],
-        uid='systemdspawner-unittest-does-not-exist',
-        working_dir='/'
+        working_dir='/systemdspawner-unittest-does-not-exist'
     )
 
     await asyncio.sleep(0.1)


### PR DESCRIPTION
The original test tries to create a failed service by passing it a uid that doesn't exist, which works as intended on systemd=229, but results in a service created in an `inactive` rather than `failed` state on systemd=239.

This commit changes the test and has it try to create a service with an invalid working dir instead of uid, and has been confirmed to work on both versions as the created service fails with an error of `200/CHDIR`.