### PR TITLE
Add simple slice support to systemd spawner

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,17 @@ information.
 
 Requires systemd 235.
 
+### `slice` ###
+
+Run the spawed notebook in a given systemd slice.  This allows aggregate configuration that
+will apply to all the units that are launched.  This can be used (for example) to control 
+the total amount of memory that all of the notebook users can use.  
+
+See https://samthursfield.wordpress.com/2015/05/07/running-firefox-in-a-cgroup-using-systemd/ for
+an example of how this could look.
+
+For detailed configuration see the [manpage](http://man7.org/linux/man-pages/man5/systemd.slice.5.html)
+
 ## Getting help ##
 
 We encourage you to ask questions on the [mailing list](https://groups.google.com/forum/#!forum/jupyter).

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Requires systemd 235.
 
 ### `slice` ###
 
-Run the spawed notebook in a given systemd slice.  This allows aggregate configuration that
+Run the spawned notebook in a given systemd slice.  This allows aggregate configuration that
 will apply to all the units that are launched.  This can be used (for example) to control 
 the total amount of memory that all of the notebook users can use.  
 

--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -17,6 +17,7 @@ async def start_transient_service(
     properties=None,
     uid=None,
     gid=None,
+    slice=None,
 ):
     """
     Start a systemd transient service with given paramters
@@ -48,6 +49,9 @@ async def start_transient_service(
     if gid is not None:
         run_cmd += ['--gid', str(gid)]
 
+    if slice is not None:
+        run_cmd += ['--slice', str(slice)]
+    
     run_cmd.append('--property=WorkingDirectory={}'.format(shlex.quote(working_dir)))
     # We unfortunately have to resort to doing cd with bash, since WorkingDirectory property
     # of systemd units can't be set for transient units via systemd-run until systemd v227.

--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -50,7 +50,7 @@ async def start_transient_service(
         run_cmd += ['--gid', str(gid)]
 
     if slice is not None:
-        run_cmd += ['--slice', str(slice)]
+        run_cmd += ['--slice={}'.format(slice)]
     
     run_cmd.append('--property=WorkingDirectory={}'.format(shlex.quote(working_dir)))
     # We unfortunately have to resort to doing cd with bash, since WorkingDirectory property

--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -137,6 +137,16 @@ class SystemdSpawner(Spawner):
         """
     ).tag(config=True)
 
+    slice = Unicode(
+        None,
+        allow_none=True,
+        help="""
+        Ensure that all users that are created are run within a given slice.
+        This allow global configuration of the maximum resources that all users
+        collectively can use by creating a a slice beforehand.
+        """
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # All traitlets configurables are configured by now
@@ -288,7 +298,8 @@ class SystemdSpawner(Spawner):
             environment_variables=env,
             properties=properties,
             uid=uid,
-            gid=gid
+            gid=gid,
+            slice=self.slice,
         )
 
         for i in range(self.start_timeout):


### PR DESCRIPTION
Let jupyterhub to configured to spawn users into a given predefined slice.  

This allows an administrator of a jupyerhub instance to limit memory/cpu usage as well as constrain access to devices etc for all users collectively under a given spawner.

Quite useful for example to limit all of jupyterhub to 1GB less than the total system memory for example