### PR TITLE
Expand user variables within unit_extra_parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,9 @@ c.SystemdSpawner.unit_extra_properties = {'LimitNOFILE': '16384'}
 ```
 Read `man systemd-run` for details on per-unit properties available in transient units.
 
+`{USERNAME}` and `{USERID}` in each parameter value will be expanded to the
+appropriate values for the user being spawned.
+
 Defaults to `{}` which doesn't add any extra properties to the transient scope.
 
 ### `isolate_tmp` ###

--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -288,6 +288,9 @@ class SystemdSpawner(Spawner):
                 for path in self.readwrite_paths
             ]
 
+        for property, value in self.unit_extra_properties.items():
+            self.unit_extra_properties[property] = self._expand_user_vars(value)
+
         properties.update(self.unit_extra_properties)
 
         await systemd.start_transient_service(


### PR DESCRIPTION
It would be useful to be able to expand user values in the configuration
options that are passed to the transient systemd unit file. This commit
enables that option and updates the documentation accordingly.

Fixes: #82