### PR TITLE
Disable user sudo by default

### DIFF
--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -78,7 +78,7 @@ class SystemdSpawner(Spawner):
     ).tag(config=True)
 
     disable_user_sudo = Bool(
-        False,
+        True,
         help="""
         Set to true to disallow becoming root (or any other user) via sudo or other means from inside the notebook
         """,


### PR DESCRIPTION
Protects against vulnerabilities such as
https://arstechnica.com/information-technology/2022/01/a-bug-lurking-for-12-years-gives-attackers-root-on-every-major-linux-distro/
or the previous sudo vulnerability.

Equivalent of https://github.com/jupyterhub/kubespawner/pull/545

This should be counted as a braking change.