### PR TITLE
RFC: systemdspawner without `systemd-run`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "jupyterhub.spawners": [
             "systemd = systemdspawner:SystemdSpawner",
             "systemdspawner = systemdspawner:SystemdSpawner",
+            "staticsystemdspawner = systemdspawner:StaticSystemdSpawner",
         ],
     },
     install_requires=[

--- a/systemdspawner/__init__.py
+++ b/systemdspawner/__init__.py
@@ -1,3 +1,4 @@
 from systemdspawner.systemdspawner import SystemdSpawner
+from systemdspawner.staticsystemdspawner import StaticSystemdSpawner
 
-__all__ = [SystemdSpawner]
+__all__ = [SystemdSpawner, StaticSystemdSpawner]

--- a/systemdspawner/staticsystemdspawner.py
+++ b/systemdspawner/staticsystemdspawner.py
@@ -185,6 +185,20 @@ class StaticSystemdSpawner(Spawner):
                 f.write(content.getvalue())
         return userconf_dir
 
+    async def move_certs(self, paths):
+        userconf_dir = self._ensure_user_spawnerconf_directory()
+        if "keyfile" in paths:
+            shutil.copy(paths["keyfile"], userconf_dir / "keyfile")
+        if "certfile" in paths:
+            shutil.copy(paths["keyfile"], userconf_dir / "certfile")
+        if "cafile" in paths:
+            shutil.copy(paths["keyfile"], userconf_dir / "cafile")
+        # TODO: The returned paths are unchanged, since there's no way to return
+        # paths, that will be resolvable later ahead of time, without resorting
+        # to systemd internals. Make the singleuser instance pick up files
+        # relative to CREDENTIALS_DIRECTORY
+        return paths
+
     async def start(self):
         self.log.info(
             "user:%s Attempting to start unit %s",

--- a/systemdspawner/staticsystemdspawner.py
+++ b/systemdspawner/staticsystemdspawner.py
@@ -86,41 +86,6 @@ class StaticSystemdSpawner(Spawner):
             USERID=self.user.id,
         )
 
-    def get_state(self):
-        """
-        Save state required to reconstruct spawner from scratch
-
-        We save the unit name, just in case the unit template was changed
-        between a restart. We do not want to lost the previously launched
-        events.
-
-        JupyterHub before 0.7 also assumed your notebook was dead if it
-        saved no state, so this helps with that too!
-        """
-        state = super().get_state()
-        state["unit_name"] = self.unit_name
-        state["escaped_name"] = self.escaped_name
-        state["unit_secrets_path"] = os.fspath(self.unit_secrets_path)
-        return state
-
-    def load_state(self, state):
-        """
-        Load state from storage required to reinstate this user's server
-
-        This runs after __init__, so we can override it with saved unit name
-        if needed. This is useful primarily when you change the unit name template
-        between restarts.
-
-        JupyterHub before 0.7 also assumed your notebook was dead if it
-        saved no state, so this helps with that too!
-        """
-        if "unit_name" in state:
-            self.unit_name = state["unit_name"]
-        if "escaped_name" in state:
-            self.escaped_name = state["escaped_name"]
-        if "unit_secrets_path" in state:
-            self.unit_secrets_path = Path(state["unit_secrets_path"])
-
     def _ensure_spawnerconf_directory(self):
         """
         Ensure that the directory we write environment files to exists.

--- a/systemdspawner/staticsystemdspawner.py
+++ b/systemdspawner/staticsystemdspawner.py
@@ -1,0 +1,315 @@
+import asyncio
+import os
+import shlex
+import shutil
+import subprocess
+from io import StringIO
+from pathlib import Path
+
+from jupyterhub.spawner import Spawner
+from jupyterhub.utils import random_port
+from traitlets import Bool, Dict, List, Unicode
+
+from systemdspawner import systemd
+
+
+class StaticSystemdSpawnerError(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+        self.jupyterhub_message = msg
+        self.jupyterhub_html_message = f"<p>{msg}</p>"
+
+
+class StaticSystemdSpawner(Spawner):
+    default_server_unit_name_template = Unicode(
+        "jupyterhub-singleuser-{USERNAME}.service",
+        help="""
+        Template to use to make the systemd service name of the default
+        singleuser server.
+
+        {USERNAME} and {USERID} are expanded.
+        """,
+    ).tag(config=True)
+    named_server_unit_name_template = Unicode(
+        "jupyterhub-singleuser-{USERNAME}@.service",
+        help="""
+        Template to use to make the systemd service names for named singleuser
+        servers. Only used when named servers are enabled.
+
+        {USERNAME} and {USERID} are expanded.
+        """,
+    ).tag(config=True)
+    unit_generator = Unicode(
+        "",
+        help="""
+        Template unit to generate singleuser server units.
+
+        If you want missing singleuser server units generated, set this to the
+        name of template unit (e.g. jupyterhub-unitgenerator@.service), that
+        you must install seperately that does this.
+
+        Leave empty to not generate missing singleuser server units.
+        """,
+    ).tag(config=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # All traitlets configurables are configured by now
+        if self.name:
+            # named server
+            self.escaped_name = systemd.escape_name(self.name)
+            self.unit_name = systemd.fill_template_name(
+                self._expand_user_vars(self.named_server_unit_name_template),
+                self.name
+            )
+        else:
+            # default server
+            self.escaped_name = ""
+            self.unit_name = self._expand_user_vars(self.default_server_unit_name_template)
+        self.unit_secrets_path = None
+
+        self.log.info(
+            "user:%s Initialized spawner with unit %s", self.user.name, self.unit_name
+        )
+
+    def _expand_user_vars(self, string):
+        """
+        Expand user related variables in a given string
+
+        Currently expands:
+          {USERNAME} -> Name of the user
+          {USERID} -> UserID
+          {SERVERNAME} -> Name of the named server
+        """
+        return string.format(
+            USERNAME=self.user.name,
+            USERID=self.user.id,
+        )
+
+    def get_state(self):
+        """
+        Save state required to reconstruct spawner from scratch
+
+        We save the unit name, just in case the unit template was changed
+        between a restart. We do not want to lost the previously launched
+        events.
+
+        JupyterHub before 0.7 also assumed your notebook was dead if it
+        saved no state, so this helps with that too!
+        """
+        state = super().get_state()
+        state["unit_name"] = self.unit_name
+        state["escaped_name"] = self.escaped_name
+        state["unit_secrets_path"] = os.fspath(self.unit_secrets_path)
+        return state
+
+    def load_state(self, state):
+        """
+        Load state from storage required to reinstate this user's server
+
+        This runs after __init__, so we can override it with saved unit name
+        if needed. This is useful primarily when you change the unit name template
+        between restarts.
+
+        JupyterHub before 0.7 also assumed your notebook was dead if it
+        saved no state, so this helps with that too!
+        """
+        if "unit_name" in state:
+            self.unit_name = state["unit_name"]
+        if "escaped_name" in state:
+            self.escaped_name = state["escaped_name"]
+        if "unit_secrets_path" in state:
+            self.unit_secrets_path = Path(state["unit_secrets_path"])
+
+    def _ensure_spawnerconf_directory(self):
+        """
+        Ensure that the directory we write environment files to exists.
+        """
+        state_dir = os.getenv("STATE_DIRECTORY")
+        if not state_dir:
+            raise StaticSystemdSpawnerError("JupyterHub service was configured without StateDirectory=")
+        state_dir = state_dir.split(":")[0]
+        spawnerconf_dir = Path(state_dir) / "spawnerconf"
+        spawnerconf_dir.mkdir(mode=0o700, exist_ok=True)
+        return spawnerconf_dir
+
+    def _ensure_user_spawnerconf_directory(self):
+        """
+        Ensure that the per user directory for spawner configuration exists.
+
+        For the default server this directory will be
+
+            $STATEDIRECTORY/spawnerconf/<username>/default
+
+        and for named servers
+
+            $STATEDIRECTORY/spawnerconf/<username>/named/<escaped servername>
+        """
+        spawnerconf_dir = self._ensure_spawnerconf_directory()
+        userconf_dir = spawnerconf_dir / self.user.name
+        userconf_dir.mkdir(mode=0o700, exist_ok=True)
+        if self.name:
+            userconf_dir = userconf_dir / "named" / self.escaped_name
+        else:
+            userconf_dir = userconf_dir / "default"
+        userconf_dir.mkdir(mode=0o700, exist_ok=True, parents=True)
+        return userconf_dir
+
+    def _write_unit_secrets(self):
+        """
+        Write out secrets for the unit to be started to spawnerconf directory.
+
+        This directory will later be picked up by LoadCredential= and create one
+        file in the credential directory for each file in the spawnerconf
+        directory.
+        """
+        # TODO: add systemd.encrypt_creds and use systemd-creds
+        # TODO: make the singleuser instance understand secrets that are not
+        # environment variables
+        userconf_dir = self._ensure_user_spawnerconf_directory()
+        envfile = userconf_dir / "envfile"
+
+        env = self.get_env()
+        with StringIO() as content:
+            for var, val in sorted(env.items()):
+                # The rules for valid shell variables and Python identifiers are
+                # similar enough: [a-zA-Z_][0-9a-zA-Z_]*
+                if not var.isidentifier():
+                    raise StaticSystemdSpawnerError(
+                        f"Illegal environment variable {var}. Aborting spawn."
+                    )
+                content.write(f"{var}={shlex.quote(val)}\n")
+
+            with envfile.open("w") as f:
+                os.fchmod(f.fileno(), 0o600)
+                f.write(content.getvalue())
+        return userconf_dir
+
+    async def start(self):
+        self.log.info(
+            "user:%s Attempting to start unit %s",
+            self.user.name,
+            self.unit_name,
+        )
+        if len(self.unit_name) > 256:
+            raise StaticSystemdSpawnerError(
+                "Unit name is too long! Please choose a shorter name for the instance."
+            )
+
+        # First let's have a look whether the template unit we want to
+        # instantiate for the user exists in the first place.
+        if not await systemd.unit_exists(self.unit_name):
+            if self.unit_generator:
+                self.log.info(
+                    "user:%s Unit %s does not exist yet. Generating it.",
+                    self.user.name,
+                    self.unit_name,
+                )
+                generator_unit = systemd.fill_template_name(self.unit_generator, self.user.name)
+                await systemd.start_service(generator_unit)
+                if not await systemd.unit_exists(self.unit_name):
+                    raise StaticSystemdSpawnerError(
+                        f"Cannot spawn JupyterHub because no unit {self.unit_name} exists for your user and could not be generated. "
+                        "Please contact your administrator."
+                    )
+            else:
+                raise StaticSystemdSpawnerError(
+                    f"Cannot spawn JupyterHub because no unit {self.unit_name} exists for your user. "
+                    "Please contact your administrator."
+                )
+
+        self.port = random_port()
+        self.log.info(
+            "user:%s Using port %s to start spawning user server %s",
+            self.user.name,
+            self.port,
+            self.name,
+        )
+
+        # If there's a unit with this name running already. This means a bug in
+        # JupyterHub, a remnant from a previous install or a failed service start
+        # from earlier. Regardless, we kill it and start ours in its place.
+        # FIXME: Carefully look at this when doing a security sweep.
+        if await systemd.service_running(self.unit_name):
+            self.log.info(
+                "user:%s Unit %s already exists but not known to JupyterHub. Killing",
+                self.user.name,
+                self.unit_name,
+            )
+            await systemd.stop_service(self.unit_name)
+            if await systemd.service_running(self.unit_name):
+                self.log.error(
+                    "Could not stop already existing unit %s",
+                    self.unit_name,
+                )
+                raise StaticSystemdSpawnerError(
+                    f"Could not stop already existing unit {self.unit_name}"
+                )
+
+        # If there's a unit with this name already but sitting in a failed state.
+        # Does a reset of the state before trying to start it up again.
+        if await systemd.service_failed(self.unit_name):
+            self.log.info(
+                "Unit %s in a failed state. Resetting state.",
+                self.unit_name,
+            )
+            await systemd.reset_service(self.unit_name)
+
+        self.unit_secrets_path = self._write_unit_secrets()
+        await systemd.start_service(self.unit_name)
+
+        for i in range(self.start_timeout):
+            is_up = await self.poll()
+            if is_up is None:
+                return (self.ip or "127.0.0.1", self.port)
+            await asyncio.sleep(1)
+
+        # At this point something went wrong and the start timed
+        # out. Let's clean up the secrets to be safe.
+        self.log.info(
+            "user:%s Spawning unit %s failed. Removing secrets %s",
+            self.user.name,
+            self.Unit_name,
+            self.unit_secrets_path,
+        )
+        if self.unit_secrets_path:
+            try:
+                shutil.rmtree(self.unit_secrets_path)
+            except FileNotFoundError:
+                self.log.info(
+                    "user:%s Could not remove secrets for unit %s at %s because they were already missing.",
+                    self.user.name,
+                    self.unit_name,
+                    self.unit_secrets_path,
+                )
+        return None
+
+    async def stop(self, now=False):
+        self.log.info(
+            "user:%s Stopping unit %s",
+            self.user.name,
+            self.unit_name,
+        )
+        await systemd.stop_service(self.unit_name)
+        if self.unit_secrets_path:
+            self.log.info(
+                "user:%s Removing secrets for unit %s at %s",
+                self.user.name,
+                self.unit_name,
+                self.unit_secrets_path,
+            )
+            try:
+                shutil.rmtree(self.unit_secrets_path)
+            except FileNotFoundError:
+                self.log.info(
+                    "user:%s Could not remove secrets for unit %s at %s because they were already missing.",
+                    self.user.name,
+                    self.unit_name,
+                    self.unit_secrets_path,
+                )
+
+
+    async def poll(self):
+        if await systemd.service_running(self.unit_name):
+            return None
+        return 1

--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -233,3 +233,17 @@ def escape_name(name):
     cmd = ['systemd-escape', name]
     proc = subprocess.run(cmd, text=True, stdout=subprocess.PIPE)
     return proc.stdout.strip()
+
+
+async def unit_exists(unit_name):
+    """
+    Check if a unit exists.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        'systemctl',
+        'cat',
+        unit_name,
+        stdout=asyncio.subprocess.DEVNULL
+    )
+    ret = await proc.wait()
+    return ret == 0

--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -9,6 +9,7 @@ import asyncio
 import os
 import re
 import shlex
+import subprocess
 import warnings
 
 # light validation of environment variable keys
@@ -214,3 +215,21 @@ async def reset_service(unit_name):
         unit_name
     )
     await proc.wait()
+
+
+def fill_template_name(template, instance):
+    """
+    Fill instance name in unit template.
+    """
+    cmd = ['systemd-escape', f'--template={template}', instance]
+    proc = subprocess.run(cmd, text=True, stdout=subprocess.PIPE)
+    return proc.stdout.strip()
+
+
+def escape_name(name):
+    """
+    Fill instance name in unit template.
+    """
+    cmd = ['systemd-escape', name]
+    proc = subprocess.run(cmd, text=True, stdout=subprocess.PIPE)
+    return proc.stdout.strip()

--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -174,6 +174,20 @@ async def service_failed(unit_name):
     return ret == 0
 
 
+async def start_service(unit_name):
+    """
+    Start service with given name.
+
+    Throws CalledProcessError if starting fails
+    """
+    proc = await asyncio.create_subprocess_exec(
+        'systemctl',
+        'start',
+        unit_name
+    )
+    await proc.wait()
+
+
 async def stop_service(unit_name):
     """
     Stop service with given name.


### PR DESCRIPTION
This is a reimplementation of what I first tried with #40 and I'm opening it as a draft for now, since it's still missing pieces that I need to document. 

This spawner is called `StaticSystemdSpawner`, since it tries to push out as much logic as possible out off the spawner and into static unit files, that are currently named like this `jupyterhub-singleuser-{USERNAME}@.service`. The only thing the spawner does is start those units with an instance name that is either name name of a named server or `default`, i.e. starting a plain instance on JupyterHub will result in the singleuser server running as `jupyterhub-singleuser-{USERNAME}@default.service`, and write out secrets for the single user server, which are passed into the service of the single user server via the credentials mechanism that exists in systemd 249 (available in Debian bullseye, I've only tested it with systemd 251, though).

Currently where these units come from is left open, I pregenerate them for all users that are supposed to be able to use JupyterHub and put them into `/run/systemd/system`. I will explore next, though, whether to allow to generate the units if they don't exist via another systemd service that is run by the spawner. 

The services I generate look something like this (simplified, because I have a few hacks on top to make JupyterLab plugins work, that want to write to the venv, which they can't write to)
```ini
[Unit]
Description=Jupyterhub Single-User Server for user {username} with name '%I'
Wants=jupyterhub.service jupyterhub-httpproxy.service

[Service]
Type=simple
User={username}

Environment="PATH=/opt/jupyter/hubenv/bin:/usr/bin:/usr/local/bin:/bin"

LoadCredential=envfile:/var/lib/jupyterhub/spawnerconf/{username}/%i
ExecStart=/opt/jupyter/jupyter-singleuser-wrapper

WorkingDirectory=/home/{username}

Slice=jupyterhub-singleuser-{username}.slice
```
Generating these service units outside of the hub and with privileges different from the user the hub is running on has the advantage, that the hub has no control over what the environment for a user looks like and nothing, e.g. sandboxing options, need to be implemented in the spawner, but can be put into the units themselves. It also allows to differentiate these options by user very easily. 

The `Slice=` does not need to exist, but one can use systemd's namespacing. This might for example look like this
```ini
# /etc/systemd/system/jupter-singleuser-.slice.d/10-defaults.conf
[Unit]
Description=Slice for %j
StopWhenUnneeded=yes

[Slice]
TasksMax=33%
CPUQuota=400%
MemoryHigh=8G
MemoryMax=9G
```
also sandboxing defaults can be made similarly
```ini
# /etc/systemd/system/jupyter-singleuser-.service.d/40-hardening.conf
[Service]
PrivateTmp=yes
PrivateDevices=yes
ProtectSystem=strict
ProtectHome=read-only
ProtectKernelTunables=yes
ProtectControlGroups=yes
ReadWritePaths=/home/%j
NoNewPrivileges=yes
```

The wrapper in the `ExecStart=` is quite simple, all it does is source the credentials file `$CREDENTIALS_DIRECTORY/envfile` and export all its variables, because credentials cannot be used as environment files (since secrets should never be environment variables, since they get inherited down the process tree). Patching the singleuser server to read secrets from a file instead of environment variables is something I've yet to do.

All in all this allows for the hub itself to run as a unprivileged user with some strong sandboxing. Using the credentials mechanism the configuration directory can also be made free of any cleartext secrets.
```ini
[Unit]
Description=Jupyterhub
After=network-online.target postgresql.service
Wants=postgresql.service
PartOf=jupyterhub.target

[Service]
User=jupyter
Environment="PATH=/opt/jupyter/hubenv/bin:/usr/bin:/usr/local/bin:/bin"
ConfigurationDirectory=jupyterhub
RuntimeDirectory=jupyterhub
StateDirectory=jupyterhub

LoadCredentialEncrypted=jupyter_configproxy_auth_token.cred
LoadCredentialEncrypted=jupyter_cookie_secret.cred
LoadCredentialEncrypted=jupyter_db_password.cred
LoadCredentialEncrypted=jupyter_ldap_password.cred

ExecStart=/opt/jupyter/hubenv/bin/jupyterhub --config ${CONFIGURATION_DIRECTORY}/jupyterhub_config.py

PrivateTmp=yes
NoNewPrivileges=yes
ProtectSystem=strict
ProtectHome=yes
WorkingDirectory=/var/lib/jupyterhub

[Install]
WantedBy=multi-user.target
```
and (when running the proxy seperately) it can be run stateless as a dynamic user with similar sandboxing.

To be able to start units I use polkit
```javascript
polkit.addRule(function(action, subject) {
    if (action.id == "org.freedesktop.systemd1.manage-units") {
	polkit.log("action=" + action);
	polkit.log("subject=" + subject);
	if (action.lookup("unit").match(/^jupyterhub-singleuser-[a-zA-Z]?\w*@[a-zA-Z0-9_\\]+.service$/)) {
	    var verb = action.lookup("verb");
	    if ((verb == "start" || verb == "stop" || verb == "reset-failed") && subject.user == "jupyter") {
		return polkit.Result.YES;
	    }
	}
    }
});
```
The same would be possible with sudo rules, but I haven't added that, since I don't use it. polkit has the advantage that it allows for `NoNewPrivileges=yes` on the hub. 

Besides automatically generating the singleuser server units on first use I still need to explore
- allowing for multiple user units `jupyterhub-singleuser-foo-username@.service` and `jupyterhub-singleuser-bar-username@.service`, chosen via the spawner options form, to allow for different setups, e.g. lab, classical notebook, collaborative or different base images (disk images or maybe OCI images) via `RootImage=`.
- running on multiple hosts, by using the systemctl switch `-H` to manage units on different hosts, for which I need to have a look at the SSH spawner.

My question: Does it make sense to integrate this here, or should I pursue a friendly fork, since I totally understand if the focus is too different.