### PR TITLE
Don't kill the whole service when a single proces OOMs

### DIFF
--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -80,6 +80,7 @@ async def start_transient_service(
     run_cmd = [
         'systemd-run',
         '--unit', unit_name,
+        '-p', 'OOMPolicy=continue',
     ]
 
     if properties is None:

--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -80,7 +80,6 @@ async def start_transient_service(
     run_cmd = [
         'systemd-run',
         '--unit', unit_name,
-        '-p', 'OOMPolicy=continue',
     ]
 
     if properties is None:
@@ -88,6 +87,10 @@ async def start_transient_service(
     else:
         properties = properties.copy()
 
+    # Set default policy so OOM only terminate the offending kernel and let the user session survive.
+    # Can be overridden in unit_extra_properties.
+    properties.setdefault('OOMPolicy', 'continue')
+        
     # ensure there is a runtime directory where we can put our env file
     # If already set, can be space-separated list of paths
     runtime_directories = properties.setdefault("RuntimeDirectory", unit_name).split()


### PR DESCRIPTION
This fixes a bug in systemd which terminate all processes in the scope if a process hits the mem_limit.

It seems to be fixed upstream, but might take a while until the distros implements it. https://github.com/systemd/systemd/issues/25376