### PR TITLE
draft: general maintenance work, release automation, tests etc.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/systemdspawner/network/updates.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: /
+    labels: [ci]
+    schedule:
+      interval: monthly
+      time: "05:00"
+      timezone: Etc/UTC

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,54 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
+name: Release
+
+# Always tests wheel building, but only publish to PyPI on pushed tags.
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - ".github/workflows/*.yaml"
+      - "!.github/workflows/release.yaml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - ".github/workflows/*.yaml"
+      - "!.github/workflows/release.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags: ["**"]
+  workflow_dispatch:
+
+jobs:
+  build-release:
+    runs-on: ubuntu-22.04
+    permissions:
+      # id-token=write is required for pypa/gh-action-pypi-publish, and the PyPI
+      # project needs to be configured to trust this workflow.
+      #
+      # ref: https://github.com/jupyterhub/team-compass/issues/648
+      #
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: install build package
+        run: |
+          pip install --upgrade pip
+          pip install build
+          pip freeze
+
+      - name: build release
+        run: |
+          python -m build --sdist --wheel .
+          ls -l dist
+
+      - name: publish to pypi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,71 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
+name: Tests
+
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/workflows/*.yaml"
+      - "!.github/workflows/test.yaml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/workflows/*.yaml"
+      - "!.github/workflows/test.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags: ["**"]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # oldest supported python and jupyterhub version
+          - python-version: "3.8"
+            pip-install-spec: "jupyterhub==2.3.0 tornado==5.0.0 sqlalchemy==1.*"
+          - python-version: "3.9"
+            pip-install-spec: "jupyterhub==2.* sqlalchemy==1.*"
+          - python-version: "3.10"
+            pip-install-spec: "jupyterhub==3.*"
+          - python-version: "3.11"
+            pip-install-spec: "jupyterhub==4.*"
+
+          # latest version of python and jupyterhub (including pre-releases)
+          - python-version: "3.x"
+            pip-install-spec: "--pre jupyterhub"
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ matrix.python-version }}"
+
+      - name: Install Node dependencies
+        run: |
+          npm install -g configurable-http-proxy
+
+      - name: Install Python dependencies
+        run: |
+          pip install ${{ matrix.pip-install-spec }}
+          pip install ".[test]"
+          pip freeze
+
+      - name: Run tests
+        run: |
+          pytest --cov=systemdspawner
+
+      # GitHub action reference: https://github.com/codecov/codecov-action
+      - uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@
 
 # systemdspawner
 
+[![Latest PyPI version](https://img.shields.io/pypi/v/jupyterhub-systemdspawner?logo=pypi)](https://pypi.python.org/pypi/jupyterhub-systemdspawner)
+[![Latest conda-forge version](https://img.shields.io/conda/vn/conda-forge/jupyterhub-systemdspawner?logo=conda-forge)](https://anaconda.org/conda-forge/jupyterhub-systemdspawner)
+[![GitHub Workflow Status - Test](https://img.shields.io/github/actions/workflow/status/jupyterhub/systemdspawner/test.yaml?logo=github&label=tests)](https://github.com/jupyterhub/systemdspawner/actions)
+[![Test coverage of code](https://codecov.io/gh/jupyterhub/systemdspawner/branch/main/graph/badge.svg)](https://codecov.io/gh/jupyterhub/systemdspawner)
+[![GitHub](https://img.shields.io/badge/issue_tracking-github-blue?logo=github)](https://github.com/jupyterhub/systemdspawner/issues)
+[![Discourse](https://img.shields.io/badge/help_forum-discourse-blue?logo=discourse)](https://discourse.jupyter.org/c/jupyterhub)
+
 The **systemdspawner** enables JupyterHub to spawn single-user
 notebook servers using [systemd](https://www.freedesktop.org/wiki/Software/systemd/).
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 **[Requirements](#requirements)** |
 **[Installation](#installation)** |
 **[Configuration](#configuration)** |
-**[Getting help](#getting-help)** |
-**[License](#license)** |
-**[Resources](#resources)**
+**[License](#license)**
 
 # systemdspawner
 
@@ -432,27 +430,9 @@ an example of how this could look.
 
 For detailed configuration see the [manpage](http://man7.org/linux/man-pages/man5/systemd.slice.5.html)
 
-## Getting help
-
-We encourage you to ask questions on the [mailing list](https://groups.google.com/forum/#!forum/jupyter).
-You can also participate in development discussions or get live help on [Gitter](https://gitter.im/jupyterhub/jupyterhub).
-
 ## License
 
 We use a shared copyright model that enables all contributors to maintain the
 copyright on their contributions.
 
 All code is licensed under the terms of the revised BSD license.
-
-## Resources
-
-#### JupyterHub and systemdspawner
-
-- [Reporting Issues](https://github.com/jupyterhub/systemdspawner/issues)
-- [Documentation for JupyterHub](http://jupyterhub.readthedocs.io/en/latest/) | [PDF (latest)](https://media.readthedocs.org/pdf/jupyterhub/latest/jupyterhub.pdf) | [PDF (stable)](https://media.readthedocs.org/pdf/jupyterhub/stable/jupyterhub.pdf)
-- [Documentation for JupyterHub's REST API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyterhub/master/docs/rest-api.yml#/default)
-
-#### Jupyter
-
-- [Documentation for Project Jupyter](http://jupyter.readthedocs.io/en/latest/index.html) | [PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)
-- [Project Jupyter website](https://jupyter.org)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,61 @@
+# How to make a release
+
+`jupyterhub-systemdspawner` is a package available on [PyPI] and on
+[conda-forge].
+
+These are the instructions on how to make a release.
+
+## Pre-requisites
+
+- Push rights to this GitHub repository
+
+## Steps to make a release
+
+1. Create a PR updating `CHANGELOG.md` with [github-activity] and continue when
+   its merged.
+
+   Advice on this procedure can be found in [this team compass
+   issue](https://github.com/jupyterhub/team-compass/issues/563).
+
+2. Checkout main and make sure it is up to date.
+
+   ```shell
+   git checkout main
+   git fetch origin main
+   git reset --hard origin/main
+   ```
+
+3. Update the version, make commits, and push a git tag with `tbump`.
+
+   ```shell
+   pip install tbump
+   ```
+
+   `tbump` will ask for confirmation before doing anything.
+
+   ```shell
+   # Example versions to set: 1.0.0, 1.0.0b1
+   VERSION=
+   tbump ${VERSION}
+   ```
+
+   Following this, the [CI system] will build and publish a release.
+
+4. Reset the version back to dev, e.g. `1.0.1.dev` after releasing `1.0.0`.
+
+   ```shell
+   # Example version to set: 1.0.1.dev
+   NEXT_VERSION=
+   tbump --no-tag ${NEXT_VERSION}.dev
+   ```
+
+5. Following the release to PyPI, an automated PR should arrive within 24 hours
+   to [conda-forge/jupyterhub-systemdspawner-feedstock] with instructions on
+   releasing to conda-forge. You are welcome to volunteer doing this, but aren't
+   required as part of making this release to PyPI.
+
+[github-activity]: https://github.com/executablebooks/github-activity
+[pypi]: https://pypi.org/project/jupyterhub-systemdspawner/
+[ci system]: https://github.com/jupyterhub/jupyterhub-systemdspawner/actions/workflows/release.yaml
+[conda-forge]: https://anaconda.org/conda-forge/jupyterhub-systemdspawner
+[conda-forge/jupyterhub-systemdspawner-feedstock]: https://github.com/conda-forge/jupyterhub-systemdspawner-feedstock

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,0 @@
-pytest
-pytest-asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ profile = "black"
 # target-version should be all supported versions, see
 # https://github.com/psf/black/issues/751#issuecomment-473066811
 target_version = [
-    "py37",
     "py38",
     "py39",
     "py310",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,16 @@ target_version = [
 ]
 
 
+# pytest is used for running Python based tests
+#
+# ref: https://docs.pytest.org/en/stable/
+#
+[tool.pytest.ini_options]
+addopts = "--verbose --color=yes --durations=10"
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+
 # tbump is used to simplify and standardize the release process when updating
 # the version, making a git commit and tag, and pushing changes.
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,32 @@ target_version = [
     "py310",
     "py311",
 ]
+
+
+# tbump is used to simplify and standardize the release process when updating
+# the version, making a git commit and tag, and pushing changes.
+#
+# ref: https://github.com/your-tools/tbump#readme
+#
+[tool.tbump]
+github_url = "https://github.com/jupyterhub/systemdspawner"
+
+[tool.tbump.version]
+current = "0.18.0.dev0"
+regex = '''
+    (?P<major>\d+)
+    \.
+    (?P<minor>\d+)
+    \.
+    (?P<patch>\d+)
+    (?P<pre>((a|b|rc)\d+)|)
+    \.?
+    (?P<dev>(?<=\.)dev\d*|)
+'''
+
+[tool.tbump.git]
+message_template = "Bump to {new_version}"
+tag_template = "v{new_version}"
+
+[[tool.tbump.file]]
+src = "setup.py"

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,11 @@ setup(
         "jupyterhub>=2.3.0",
         "tornado>=5.0",
     ],
+    extras_require={
+        "test": [
+            "pytest",
+            "pytest-asyncio",
+            "pytest-cov",
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,9 @@ setup(
             "systemdspawner = systemdspawner:SystemdSpawner",
         ],
     },
+    python_requires=">=3.8",
     install_requires=[
-        "jupyterhub>=0.9",
+        "jupyterhub>=2.3.0",
         "tornado>=5.0",
     ],
 )


### PR DESCRIPTION
- readme: add badges for releases/tests/coverage/issues/discourse
- readme: remove outdated getting help and resources section
- ci: add dependabot to bump future github actions
- maint, breaking: require python 3.8+ and jh 2.3.0+
- Add release automation and docs
- Add test automation
