### PR TITLE
readme: remove resources section and link to discourse forum instead of mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 **[Requirements](#requirements)** |
 **[Installation](#installation)** |
 **[Configuration](#configuration)** |
+**[Getting help](#getting-help)** |
 **[License](#license)**
 
 # systemdspawner
@@ -429,6 +430,10 @@ See https://samthursfield.wordpress.com/2015/05/07/running-firefox-in-a-cgroup-u
 an example of how this could look.
 
 For detailed configuration see the [manpage](http://man7.org/linux/man-pages/man5/systemd.slice.5.html)
+
+## Getting help
+
+We encourage you to ask questions in the [Jupyter Discourse forum](https://discourse.jupyter.org/c/jupyterhub).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 **[Requirements](#requirements)** |
 **[Installation](#installation)** |
 **[Configuration](#configuration)** |
-**[Getting help](#getting-help)** |
-**[License](#license)** |
-**[Resources](#resources)**
+**[License](#license)**
 
 # systemdspawner
 
@@ -432,27 +430,9 @@ an example of how this could look.
 
 For detailed configuration see the [manpage](http://man7.org/linux/man-pages/man5/systemd.slice.5.html)
 
-## Getting help
-
-We encourage you to ask questions on the [mailing list](https://groups.google.com/forum/#!forum/jupyter).
-You can also participate in development discussions or get live help on [Gitter](https://gitter.im/jupyterhub/jupyterhub).
-
 ## License
 
 We use a shared copyright model that enables all contributors to maintain the
 copyright on their contributions.
 
 All code is licensed under the terms of the revised BSD license.
-
-## Resources
-
-#### JupyterHub and systemdspawner
-
-- [Reporting Issues](https://github.com/jupyterhub/systemdspawner/issues)
-- [Documentation for JupyterHub](http://jupyterhub.readthedocs.io/en/latest/) | [PDF (latest)](https://media.readthedocs.org/pdf/jupyterhub/latest/jupyterhub.pdf) | [PDF (stable)](https://media.readthedocs.org/pdf/jupyterhub/stable/jupyterhub.pdf)
-- [Documentation for JupyterHub's REST API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyterhub/master/docs/rest-api.yml#/default)
-
-#### Jupyter
-
-- [Documentation for Project Jupyter](http://jupyter.readthedocs.io/en/latest/index.html) | [PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)
-- [Project Jupyter website](https://jupyter.org)


### PR DESCRIPTION
We have badges (#112) to help nudge users to report issues and ask for help.

The mailing list may be relevant still, I've never used it so I don't
know if its suitable to suggest people to write there.
