### PR TITLE
maint, breaking: require python 3.8+, jupyterhub 2.3.0+, tornado 5.1+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ profile = "black"
 # target-version should be all supported versions, see
 # https://github.com/psf/black/issues/751#issuecomment-473066811
 target_version = [
-    "py37",
     "py38",
     "py39",
     "py310",

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,9 @@ setup(
             "systemdspawner = systemdspawner:SystemdSpawner",
         ],
     },
+    python_requires=">=3.8",
     install_requires=[
-        "jupyterhub>=0.9",
-        "tornado>=5.0",
+        "jupyterhub>=2.3.0",
+        "tornado>=5.1",
     ],
 )


### PR DESCRIPTION
I want to drop support just to make future maintenance easier, and do it before 1.0.0 is released - something I work towards now to ship with the littlest jupyterhub distribution that is also about to release 1.0.0.

For example I know pytest-jupyterhub that I may want to use in order to help test this spawner requires py38 and jupyterhub 2.3.