### PR TITLE
Require systemd v243+, recommend systemd v245+, test against systemd v245

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,8 +24,6 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
-
     strategy:
       fail-fast: false
       matrix:
@@ -33,17 +31,23 @@ jobs:
           # oldest supported python and jupyterhub version
           - python-version: "3.8"
             pip-install-spec: "jupyterhub==2.3.0 tornado==5.1.0 sqlalchemy==1.*"
+            runs-on: ubuntu-20.04
           - python-version: "3.9"
             pip-install-spec: "jupyterhub==2.* sqlalchemy==1.*"
+            runs-on: ubuntu-22.04
           - python-version: "3.10"
             pip-install-spec: "jupyterhub==3.*"
+            runs-on: ubuntu-22.04
           - python-version: "3.11"
             pip-install-spec: "jupyterhub==4.*"
+            runs-on: ubuntu-22.04
 
           # latest version of python and jupyterhub (including pre-releases)
           - python-version: "3.x"
             pip-install-spec: "--pre jupyterhub"
+            runs-on: ubuntu-latest
 
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -78,16 +78,18 @@ The following features are currently available:
 
 ## Requirements
 
-### Systemd
+### Systemd and Linux distributions
 
-Systemd Spawner requires you to use a Linux Distro that ships with at least
-systemd v211. The security related features require systemd v228 or v227. We recommend running
-with at least systemd v228. You can check which version of systemd is running with:
+SystemdSpawner 1 is recommended to be used with systemd version 245 or higher,
+but _may_ work with systemd version 243-244 as well. Below are examples of Linux
+distributions that use systemd and has a recommended version.
 
-```bash
-$ systemctl --version | head -1
-systemd 231
-```
+- Ubuntu 20.04+
+- Debian 11+
+- Rocky 9+ / CentOS 9+
+
+The command `systemctl --version` can be used to verify that systemd is used,
+and what version is used.
 
 ### Kernel Configuration
 
@@ -114,26 +116,6 @@ If running with `c.SystemdSpawner.dynamic_users = True`, no local user accounts
 are required. Systemd will automatically create dynamic users as required.
 See [this blog post](http://0pointer.net/blog/dynamic-users-with-systemd.html) for
 details.
-
-### Linux Distro compatibility
-
-#### Ubuntu 16.04 LTS
-
-We recommend running this with systemd spawner. The default kernel has all the features
-we need, and a recent enough version of systemd to give us all the features.
-
-#### Debian Jessie
-
-The systemd version that ships by default with Jessie doesn't provide all the features
-we need, and the default kernel doesn't ship with the features we need. However, if
-you [enable jessie-backports](https://backports.debian.org/Instructions/) you can
-install a new enough version of systemd and linux kernel to get it to work fine.
-
-#### Centos 7
-
-The kernel has all the features we need, but the version of systemd (219) is too old
-for the security related features of systemdspawner. However, basic spawning,
-memory & cpu limiting will work.
 
 ## Installation
 
@@ -332,9 +314,6 @@ c.SystemdSpawner.isolate_tmp = True
 
 Defaults to false.
 
-This requires systemd version > 227. If you enable this in earlier versions, spawning will
-fail.
-
 ### `isolate_devices`
 
 Setting this to true provides a separate, private `/dev` for each user. This prevents the
@@ -348,9 +327,6 @@ c.SystemdSpawner.isolate_devices = True
 
 Defaults to false.
 
-This requires systemd version > 227. If you enable this in earlier versions, spawning will
-fail.
-
 ### `disable_user_sudo`
 
 Setting this to true prevents users from being able to use `sudo` (or any other means) to
@@ -363,9 +339,6 @@ c.SystemdSpawner.disable_user_sudo = True
 ```
 
 Defaults to false.
-
-This requires systemd version > 228. If you enable this in earlier versions, spawning will
-fail.
 
 ### `readonly_paths`
 
@@ -384,9 +357,6 @@ appropriate values for the user being spawned.
 
 Defaults to `None` which disables this feature.
 
-This requires systemd version > 228. If you enable this in earlier versions, spawning will
-fail. It can also contain only directories (not files) until systemd version 231.
-
 ### `readwrite_paths`
 
 List of filesystem paths that should be mounted readwrite for the users' notebook server. This
@@ -403,9 +373,6 @@ appropriate values for the user being spawned.
 
 Defaults to `None` which disables this feature.
 
-This requires systemd version > 228. If you enable this in earlier versions, spawning will
-fail. It can also contain only directories (not files) until systemd version 231.
-
 ### `dynamic_users`
 
 Allocate system users dynamically for each user.
@@ -417,8 +384,6 @@ is deallocated whenever the user's server is not running.
 
 See http://0pointer.net/blog/dynamic-users-with-systemd.html for more
 information.
-
-Requires systemd 235.
 
 ### `slice`
 

--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -9,6 +9,7 @@ import asyncio
 import os
 import re
 import shlex
+import subprocess
 import warnings
 
 # light validation of environment variable keys
@@ -198,3 +199,20 @@ async def reset_service(unit_name):
     """
     proc = await asyncio.create_subprocess_exec("systemctl", "reset-failed", unit_name)
     await proc.wait()
+
+
+def get_systemd_version():
+    """
+    Returns systemd's major version, or None if failing to do so.
+    """
+    try:
+        version_response = subprocess.check_output(["systemctl", "--version"])
+        # Example response from Ubuntu 22.04:
+        #
+        # systemd 249 (249.11-0ubuntu3.9)
+        # +PAM +AUDIT +SELINUX +APPARMOR +IMA +SMACK +SECCOMP +GCRYPT +GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 -PWQUALITY -P11KIT -QRENCODE +BZIP2 +LZ4 +XZ +ZLIB +ZSTD -XKBCOMMON +UTMP +SYSVINIT default-hierarchy=unified
+        #
+        version = int(float(version_response.split()[1]))
+        return version
+    except:
+        return None

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -11,6 +11,17 @@ import time
 from systemdspawner import systemd
 
 
+def test_get_systemd_version():
+    """
+    Test getting systemd version as an integer, where the assumption for the
+    tests are that systemd is actually running at all.
+    """
+    systemd_version = systemd.get_systemd_version()
+    assert isinstance(
+        systemd_version, int
+    ), "Either systemd wasn't running, or we failed to parse the version into an integer!"
+
+
 async def test_simple_start():
     unit_name = "systemdspawner-unittest-" + str(time.time())
     await systemd.start_transient_service(


### PR DESCRIPTION
### Summary

This makes existing requirements explicit, but doesn't increase them. Due to that, its not really breaking.

### Changes

- **Explicitily fail on startup when systemd version <243**
  This isn't breaking because v0.17 is already broken for systemd version <243 because the OOMPolicy config set in #101 was [introduced in systemd version 243] (https://github.com/systemd/systemd/commit/afcfaa695cd00b713e7d57e1829da90b692ac6f8) and makes user servers fail to start.
- **Warn on startup when systemd versions <245**
  This is motivated by us only testing on systemd version 245.
- **Add tests against systemd version 245 in Ubuntu 20.04** 
  Version 245 is easy for us to test against, because its part of Ubuntu 20.04. Yuvi suggested testing against the second most newest ubuntu LTS release's systemd version, which is a perfect policy in my mind because of the environments provided by CI systems like GitHub Actions. In GitHub actions, Ubuntu 20.04 and 22.04 is available, but [Ubuntu 18.04 isn't available any more](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/) and was removed a while after 22.04 had been added.

### Related

- Closes #116
- Closes #106
- v0.17 stopped working without systemd v243+
  - closes #105
- v0.15 stopped working without systemd v219+
  - Closes #80
  - Closes #79
- Closes #6