### PR TITLE
Add basic start/stop test against a jupyterhub

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,10 +68,11 @@ jobs:
           pip freeze
 
       - name: Run tests
-        # Running tests requires sudo permissions, but we also need to preserve
-        # the PATH to have pytest available etc.
+        # Tests needs to be run as root and we have to specify a non-root
+        # non-nobody system user to test with. We also need to preserve the PATH
+        # when running as root.
         run: |
-          sudo -E "PATH=$PATH" bash -c "pytest --cov=systemdspawner"
+          sudo -E "PATH=$PATH" bash -c "pytest --cov=systemdspawner --system-test-user=$(whoami)"
 
       # GitHub action reference: https://github.com/codecov/codecov-action
       - uses: codecov/codecov-action@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py37-plus
+          - --py38-plus
 
   # Autoformat: Python code
   - repo: https://github.com/PyCQA/autoflake

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,71 @@
 # Contributing
 
-Welcome! As a [Jupyter](https://jupyter.org) project, we follow the [Jupyter contributor guide](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html).
+Welcome! As a [Jupyter] project, you can follow the [Jupyter contributor guide].
+
+Make sure to also follow [Project Jupyter's Code of Conduct] for a friendly and
+welcoming collaborative environment.
+
+[jupyter]: https://jupyter.org
+[project jupyter's code of conduct]: https://github.com/jupyter/governance/blob/HEAD/conduct/code_of_conduct.md
+[jupyter contributor guide]: https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html
+
+## Setting up a local development environment
+
+To setup a local development environment to test changes to systemdspawner
+locally, a pre-requisite is to have systemd running in your system environment.
+You can check if you do by running `systemctl --version` in a terminal.
+
+Start by setting up Python, Node, and Git by reading the _System requirements_
+section in [jupyterhub's contribution guide].
+
+Then do the following:
+
+```shell
+# install configurable-http-proxy, a dependency for running a jupyterhub
+npm install -g configurable-http-proxy
+```
+
+```shell
+# clone the systemdspawner github repository to your local computer
+git clone https://github.com/jupyterhub/systemdspawner
+cd systemdspawner
+```
+
+```shell
+# install systemdspawner and test dependencies based on code in this folder
+pip install --editable ".[test]"
+```
+
+We recommend installing `pre-commit` and configuring it to automatically run
+autoformatting before you make a git commit. This can be done by:
+
+```shell
+# configure pre-commit to help with autoformatting checks before commits are made
+pip install pre-commit
+pre-commit install --install-hooks
+```
+
+[jupyterhub's contribution guide]: https://jupyterhub.readthedocs.io/en/stable/contributing/setup.html#system-requirements
+
+## Running tests
+
+A JupyterHub configured to use SystemdSpawner needs to be run as root, so due to
+that we need to run tests as root as well. To still have Python available, we
+may need to preserve the PATH when switching to root by using sudo as well, and
+perhaps also other environment variables.
+
+```shell
+# run pytest as root, preserving environment variables, including PATH
+sudo -E "PATH=$PATH" bash -c "pytest"
+```
+
+To run all tests, there needs to be a non-root and non-nobody user specified
+explicitly via the systemdspawner defined `--system-test-user=USERNAME` flag for
+pytest.
+
+```shell
+# --system-test-user allows a user server to be started by SystemdSpawner as this
+# existing system user, which involves running a user server in the user's home
+# directory
+sudo -E "PATH=$PATH" bash -c "pytest --system-test-user=USERNAME"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,11 @@ target_version = [
 addopts = "--verbose --color=yes --durations=10"
 asyncio_mode = "auto"
 testpaths = ["tests"]
+# warnings we can safely ignore stemming from jupyterhub 3 + sqlalchemy 2
+filterwarnings = [
+    'ignore:.*The new signature is "def engine_connect\(conn\)"*:sqlalchemy.exc.SADeprecationWarning',
+    'ignore:.*The new signature is "def engine_connect\(conn\)"*:sqlalchemy.exc.SAWarning',
+]
 
 
 # tbump is used to simplify and standardize the release process when updating

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             "pytest",
             "pytest-asyncio",
             "pytest-cov",
+            "pytest-jupyterhub",
         ],
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def pytest_configure(config):
     A pytest recognized function to adjust configuration before running tests.
     """
     config.addinivalue_line(
-        "markers", "github_ci: only to be run in a github ci environment"
+        "markers", "github_actions: only to be run in a github actions ci environment"
     )
 
     # These markers are registered to avoid warnings triggered by importing from
@@ -37,9 +37,11 @@ def pytest_runtest_setup(item):
     Several of these tests work against the host system directly, so to protect
     users from issues we make these not run.
     """
-    if not os.environ("GITHUB_CI"):
-        has_github_ci_mark = any(mark for mark in item.iter_markers(name="github_ci"))
-        if has_github_ci_mark:
+    if not os.environ.get("GITHUB_ACTIONS"):
+        has_github_actions_mark = any(
+            mark for mark in item.iter_markers(name="github_actions")
+        )
+        if has_github_actions_mark:
             pytest.skip("Skipping test marked safe only for GitHub's CI environment.")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,5 +52,6 @@ async def systemdspawner_config():
     """
     config = Config()
     config.JupyterHub.spawner_class = "systemd"
+    config.JupyterHub.cookie_secret = "abc123"
 
     return config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+import os
+
+import pytest
+from traitlets.config import Config
+
+# pytest-jupyterhub provides a pytest-plugin, and from it we get various
+# fixtures, where we make use of hub_app that builds on MockHub, which defaults
+# to providing a MockSpawner.
+#
+# ref: https://github.com/jupyterhub/pytest-jupyterhub
+# ref: https://github.com/jupyterhub/jupyterhub/blob/4.0.0/jupyterhub/tests/mocking.py#L224
+#
+pytest_plugins = [
+    "jupyterhub-spawners-plugin",
+]
+
+
+def pytest_configure(config):
+    """
+    A pytest recognized function to adjust configuration before running tests.
+    """
+    config.addinivalue_line(
+        "markers", "github_ci: only to be run in a github ci environment"
+    )
+
+    # These markers are registered to avoid warnings triggered by importing from
+    # jupyterhub.tests.test_api in test_systemspawner.py.
+    config.addinivalue_line("markers", "role: dummy")
+    config.addinivalue_line("markers", "user: dummy")
+    config.addinivalue_line("markers", "slow: dummy")
+    config.addinivalue_line("markers", "group: dummy")
+    config.addinivalue_line("markers", "services: dummy")
+
+
+def pytest_runtest_setup(item):
+    """
+    Several of these tests work against the host system directly, so to protect
+    users from issues we make these not run.
+    """
+    if not os.environ("GITHUB_CI"):
+        has_github_ci_mark = any(mark for mark in item.iter_markers(name="github_ci"))
+        if has_github_ci_mark:
+            pytest.skip("Skipping test marked safe only for GitHub's CI environment.")
+
+
+@pytest.fixture
+async def systemdspawner_config():
+    """
+    Represents the base configuration of relevance to test SystemdSpawner.
+    """
+    config = Config()
+    config.JupyterHub.spawner_class = "systemd"
+
+    return config

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -8,8 +8,6 @@ import os
 import tempfile
 import time
 
-import pytest
-
 from systemdspawner import systemd
 
 
@@ -24,7 +22,6 @@ def test_get_systemd_version():
     ), "Either systemd wasn't running, or we failed to parse the version into an integer!"
 
 
-@pytest.mark.github_actions
 async def test_simple_start():
     unit_name = "systemdspawner-unittest-" + str(time.time())
     await systemd.start_transient_service(
@@ -38,7 +35,6 @@ async def test_simple_start():
     assert not await systemd.service_running(unit_name)
 
 
-@pytest.mark.github_actions
 async def test_service_failed_reset():
     """
     Test service_failed and reset_service
@@ -61,7 +57,6 @@ async def test_service_failed_reset():
     assert not await systemd.service_failed(unit_name)
 
 
-@pytest.mark.github_actions
 async def test_service_running_fail():
     """
     Test service_running failing when there's no service.
@@ -71,7 +66,6 @@ async def test_service_running_fail():
     assert not await systemd.service_running(unit_name)
 
 
-@pytest.mark.github_actions
 async def test_env_setting():
     unit_name = "systemdspawner-unittest-" + str(time.time())
     with tempfile.TemporaryDirectory() as d:
@@ -113,7 +107,6 @@ async def test_env_setting():
         assert not os.path.exists(env_file)
 
 
-@pytest.mark.github_actions
 async def test_workdir():
     unit_name = "systemdspawner-unittest-" + str(time.time())
     _, env_filename = tempfile.mkstemp()
@@ -133,7 +126,6 @@ async def test_workdir():
             assert text == d
 
 
-@pytest.mark.github_actions
 async def test_slice():
     unit_name = "systemdspawner-unittest-" + str(time.time())
     _, env_filename = tempfile.mkstemp()
@@ -159,7 +151,6 @@ async def test_slice():
         assert b"user.slice" in stdout
 
 
-@pytest.mark.github_actions
 async def test_properties_string():
     """
     Test that setting string properties works
@@ -189,7 +180,6 @@ async def test_properties_string():
             assert text == "/bind-test"
 
 
-@pytest.mark.github_actions
 async def test_properties_list():
     """
     Test setting multiple values for a property
@@ -226,7 +216,6 @@ async def test_properties_list():
             assert text == d
 
 
-@pytest.mark.github_actions
 async def test_uid_gid():
     """
     Test setting uid and gid

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -8,6 +8,8 @@ import os
 import tempfile
 import time
 
+import pytest
+
 from systemdspawner import systemd
 
 
@@ -22,6 +24,7 @@ def test_get_systemd_version():
     ), "Either systemd wasn't running, or we failed to parse the version into an integer!"
 
 
+@pytest.mark.github_actions
 async def test_simple_start():
     unit_name = "systemdspawner-unittest-" + str(time.time())
     await systemd.start_transient_service(
@@ -35,6 +38,7 @@ async def test_simple_start():
     assert not await systemd.service_running(unit_name)
 
 
+@pytest.mark.github_actions
 async def test_service_failed_reset():
     """
     Test service_failed and reset_service
@@ -57,6 +61,7 @@ async def test_service_failed_reset():
     assert not await systemd.service_failed(unit_name)
 
 
+@pytest.mark.github_actions
 async def test_service_running_fail():
     """
     Test service_running failing when there's no service.
@@ -66,6 +71,7 @@ async def test_service_running_fail():
     assert not await systemd.service_running(unit_name)
 
 
+@pytest.mark.github_actions
 async def test_env_setting():
     unit_name = "systemdspawner-unittest-" + str(time.time())
     with tempfile.TemporaryDirectory() as d:
@@ -107,6 +113,7 @@ async def test_env_setting():
         assert not os.path.exists(env_file)
 
 
+@pytest.mark.github_actions
 async def test_workdir():
     unit_name = "systemdspawner-unittest-" + str(time.time())
     _, env_filename = tempfile.mkstemp()
@@ -126,6 +133,7 @@ async def test_workdir():
             assert text == d
 
 
+@pytest.mark.github_actions
 async def test_slice():
     unit_name = "systemdspawner-unittest-" + str(time.time())
     _, env_filename = tempfile.mkstemp()
@@ -151,6 +159,7 @@ async def test_slice():
         assert b"user.slice" in stdout
 
 
+@pytest.mark.github_actions
 async def test_properties_string():
     """
     Test that setting string properties works
@@ -180,6 +189,7 @@ async def test_properties_string():
             assert text == "/bind-test"
 
 
+@pytest.mark.github_actions
 async def test_properties_list():
     """
     Test setting multiple values for a property
@@ -216,6 +226,7 @@ async def test_properties_list():
             assert text == d
 
 
+@pytest.mark.github_actions
 async def test_uid_gid():
     """
     Test setting uid and gid

--- a/tests/test_systemdspawner.py
+++ b/tests/test_systemdspawner.py
@@ -1,73 +1,33 @@
-"""
-These tests are running JupyterHub configured with a SystemdSpawner and starting
-a server for the specific user named "runner". It is not meant to be run outside
-a CI system.
-"""
-
-import subprocess
-
-import pytest
 from jupyterhub.tests.mocking import public_url
 from jupyterhub.tests.test_api import add_user, api_request
 from jupyterhub.utils import url_path_join
 from tornado.httpclient import AsyncHTTPClient
 
+from systemdspawner import systemd
 
-def _get_systemdspawner_user_unit(username):
-    """
-    Returns an individual SystemdSpawner's created systemd units representing a
-    specific user server.
 
-    Note that --output=json is only usable in systemd 246+, so we have to rely
-    on this manual parsing.
+async def test_start_stop(hub_app, systemdspawner_config, pytestconfig):
     """
+    Starts a user server, verifies access to its /api/status endpoint, and stops
+    the server.
+
+    About using the root and nobody user:
+
+      - A jupyter server started as root will error without the user server being
+        passed the --allow-root flag.
+
+      - SystemdSpawner runs the user server with a working directory set to the
+        user's home home directory, which for the nobody user is /nonexistent on
+        ubunutu.
+    """
+    # test is skipped unless pytest is run with --system-test-user=USERNAME
+    username = pytestconfig.getoption("--system-test-user", skip=True)
     unit_name = f"jupyter-{username}-singleuser.service"
-    output = subprocess.check_output(
-        ["systemctl", "list-units", "--no-pager", "--all", "--plain", unit_name],
-        text=True,
-    )
 
-    user_unit = output.split("\n")[1].split(maxsplit=4)
-    if user_unit[0] != unit_name:
-        return None
-
-    # Mimics the output we could get from using --output=json in the future when
-    # we can test only against systemd 246+.
-    #
-    # [
-    #     {
-    #         "unit": "jupyter-runner-singleuser.service",
-    #         "load": "loaded",
-    #         "active": "active",
-    #         "sub": "running",
-    #         "description": "/bin/bash -c cd /home/runner && exec jupyterhub-singleuser "
-    #     }
-    # ]
-    #
-    # load   = Reflects whether the unit definition was properly loaded.
-    # active = The high-level unit activation state, i.e. generalization of SUB.
-    # sub    = The low-level unit activation state, values depend on unit type.
-    #
-    return {
-        "unit": user_unit[0],
-        "load": user_unit[1],
-        "active": user_unit[2],
-        "sub": user_unit[3],
-        "description": user_unit[4],
-    }
-
-
-@pytest.mark.github_actions
-async def test_start_stop(hub_app, systemdspawner_config):
-    """
-    This tests starts the default user server, access its /api/status endpoint,
-    and stops the server.
-    """
     test_config = {}
     systemdspawner_config.merge(test_config)
     app = await hub_app(systemdspawner_config)
 
-    username = "runner"
     add_user(app.db, app, name=username)
     user = app.users[username]
 
@@ -82,13 +42,9 @@ async def test_start_stop(hub_app, systemdspawner_config):
     assert r.status_code in {201, 200}, r.text
 
     # verify the server is started via systemctl
-    user_unit = _get_systemdspawner_user_unit(username)
-    assert user_unit
-    assert user_unit["load"] == "loaded"
-    assert user_unit["active"] == "active"
-    assert user_unit["sub"] == "running"
+    assert await systemd.service_running(unit_name)
 
-    # very the server is started by accessing the server's api/status
+    # verify the server is started by accessing the server's api/status
     token = user.new_api_token()
     url = url_path_join(public_url(app, user), "api/status")
     headers = {"Authorization": f"token {token}"}
@@ -108,6 +64,4 @@ async def test_start_stop(hub_app, systemdspawner_config):
     assert r.status_code in {204, 200}, r.text
 
     # verify the server is stopped via systemctl
-    user_unit = _get_systemdspawner_user_unit(username)
-    print(user_unit)
-    assert not user_unit
+    assert not await systemd.service_running(unit_name)

--- a/tests/test_systemdspawner.py
+++ b/tests/test_systemdspawner.py
@@ -57,7 +57,7 @@ def _get_systemdspawner_user_unit(username):
     }
 
 
-@pytest.mark.github_ci
+@pytest.mark.github_actions
 async def test_start_stop(hub_app, systemdspawner_config):
     """
     This tests starts the default user server, access its /api/status endpoint,

--- a/tests/test_systemdspawner.py
+++ b/tests/test_systemdspawner.py
@@ -1,0 +1,113 @@
+"""
+These tests are running JupyterHub configured with a SystemdSpawner and starting
+a server for the specific user named "runner". It is not meant to be run outside
+a CI system.
+"""
+
+import subprocess
+
+import pytest
+from jupyterhub.tests.mocking import public_url
+from jupyterhub.tests.test_api import add_user, api_request
+from jupyterhub.utils import url_path_join
+from tornado.httpclient import AsyncHTTPClient
+
+
+def _get_systemdspawner_user_unit(username):
+    """
+    Returns an individual SystemdSpawner's created systemd units representing a
+    specific user server.
+
+    Note that --output=json is only usable in systemd 246+, so we have to rely
+    on this manual parsing.
+    """
+    unit_name = f"jupyter-{username}-singleuser.service"
+    output = subprocess.check_output(
+        ["systemctl", "list-units", "--no-pager", "--all", "--plain", unit_name],
+        text=True,
+    )
+
+    user_unit = output.split("\n")[1].split(maxsplit=4)
+    if user_unit[0] != unit_name:
+        return None
+
+    # Mimics the output we could get from using --output=json in the future when
+    # we can test only against systemd 246+.
+    #
+    # [
+    #     {
+    #         "unit": "jupyter-runner-singleuser.service",
+    #         "load": "loaded",
+    #         "active": "active",
+    #         "sub": "running",
+    #         "description": "/bin/bash -c cd /home/runner && exec jupyterhub-singleuser "
+    #     }
+    # ]
+    #
+    # load   = Reflects whether the unit definition was properly loaded.
+    # active = The high-level unit activation state, i.e. generalization of SUB.
+    # sub    = The low-level unit activation state, values depend on unit type.
+    #
+    return {
+        "unit": user_unit[0],
+        "load": user_unit[1],
+        "active": user_unit[2],
+        "sub": user_unit[3],
+        "description": user_unit[4],
+    }
+
+
+@pytest.mark.github_ci
+async def test_start_stop(hub_app, systemdspawner_config):
+    """
+    This tests starts the default user server, access its /api/status endpoint,
+    and stops the server.
+    """
+    test_config = {}
+    systemdspawner_config.merge(test_config)
+    app = await hub_app(systemdspawner_config)
+
+    username = "runner"
+    add_user(app.db, app, name=username)
+    user = app.users[username]
+
+    # start the server with a HTTP POST request to jupyterhub's REST API
+    r = await api_request(app, "users", username, "server", method="post")
+    pending = r.status_code == 202
+    while pending:
+        # check server status
+        r = await api_request(app, "users", username)
+        user_info = r.json()
+        pending = user_info["servers"][""]["pending"]
+    assert r.status_code in {201, 200}, r.text
+
+    # verify the server is started via systemctl
+    user_unit = _get_systemdspawner_user_unit(username)
+    assert user_unit
+    assert user_unit["load"] == "loaded"
+    assert user_unit["active"] == "active"
+    assert user_unit["sub"] == "running"
+
+    # very the server is started by accessing the server's api/status
+    token = user.new_api_token()
+    url = url_path_join(public_url(app, user), "api/status")
+    headers = {"Authorization": f"token {token}"}
+    resp = await AsyncHTTPClient().fetch(url, headers=headers)
+    assert resp.effective_url == url
+    resp.rethrow()
+    assert "kernels" in resp.body.decode("utf-8")
+
+    # stop the server via a HTTP DELETE request to jupyterhub's REST API
+    r = await api_request(app, "users", username, "server", method="delete")
+    pending = r.status_code == 202
+    while pending:
+        # check server status
+        r = await api_request(app, "users", username)
+        user_info = r.json()
+        pending = user_info["servers"][""]["pending"]
+    assert r.status_code in {204, 200}, r.text
+
+    # verify the server is stopped via systemctl
+    user_unit = _get_systemdspawner_user_unit(username)
+    print(user_unit)
+    assert not user_unit

--- a/tests/test_systemdspawner.py
+++ b/tests/test_systemdspawner.py
@@ -11,6 +11,10 @@ async def test_start_stop(hub_app, systemdspawner_config, pytestconfig):
     Starts a user server, verifies access to its /api/status endpoint, and stops
     the server.
 
+    This test is skipped unless pytest is passed --system-test-user=USERNAME.
+    The started user server process will run as the user in the user's home
+    folder, which perhaps is fine, but maybe not.
+
     About using the root and nobody user:
 
       - A jupyter server started as root will error without the user server being
@@ -20,7 +24,6 @@ async def test_start_stop(hub_app, systemdspawner_config, pytestconfig):
         user's home home directory, which for the nobody user is /nonexistent on
         ubunutu.
     """
-    # test is skipped unless pytest is run with --system-test-user=USERNAME
     username = pytestconfig.getoption("--system-test-user", skip=True)
     unit_name = f"jupyter-{username}-singleuser.service"
 


### PR DESCRIPTION
Test coverage before this PR:

```
---------- coverage: platform linux, python 3.11.3-final-0 -----------
Name                               Stmts   Miss  Cover
------------------------------------------------------
systemdspawner/__init__.py             2      0   100%
systemdspawner/systemd.py             70      5    93%
systemdspawner/systemdspawner.py     100     72    28%
------------------------------------------------------
TOTAL                                172     77    55%
```

Test coverage after this PR:

```
---------- coverage: platform linux, python 3.11.3-final-0 -----------
Name                               Stmts   Miss  Cover
------------------------------------------------------
systemdspawner/__init__.py             2      0   100%
systemdspawner/systemd.py             78      7    91%
systemdspawner/systemdspawner.py     111     32    71%
------------------------------------------------------
TOTAL                                191     39    80%
```