### PR TITLE
Add `cpu_weight` config, relates to Systemd's CPUAccounting and CPUWeight

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ This works out perfect for most cases, since this allows users to burst up and
 use all CPU when nobody else is using CPU & forces them to automatically yield
 when other users want to use the CPU.
 
-The share of access can be adjusted with the `cpu_weight` option.
+The share of access each user gets can be adjusted with the `cpu_weight` option.
 
 ### `cpu_weight` ###
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ in your `jupyterhub_config.py` file:
 
 - **[`mem_limit`](#mem_limit)**
 - **[`cpu_limit`](#cpu_limit)**
+- **[`cpu_weight`](#cpu_weight)**
 - **[`user_workingdir`](#user_workingdir)**
 - **[`username_template`](#username_template)**
 - **[`default_shell`](#default_shell)**
@@ -213,6 +214,23 @@ of how many processes each user is running, they all get equal access to the CPU
 This works out perfect for most cases, since this allows users to burst up and
 use all CPU when nobody else is using CPU & forces them to automatically yield
 when other users want to use the CPU.
+
+The share of access can be adjusted with the `cpu_weight` option.
+
+### `cpu_weight` ###
+
+An integer representing the share of CPU time each user can use. A user with 
+a `cpu_weight` of 200 will get 2x access to the CPU than a user with a `cpu_weight`
+of 100, which is the system default.  
+
+```python
+c.SystemdSpawner.cpu_weight = 100
+```
+
+Defaults to `None`, which implicitly means 100.
+
+This info is exposed to the single-user server as the environment variable
+`CPU_WEIGHT` as an integer.
 
 ### `user_workingdir`
 

--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -289,7 +289,7 @@ class SystemdSpawner(Spawner):
                 working_dir = self._expand_user_vars(self.user_workingdir)
 
         if self.cpu_weight:
-            env['CPU_WEIGHT'] = str(self.cpu_weight)                
+            env["CPU_WEIGHT"] = str(self.cpu_weight)
 
         if self.isolate_tmp:
             properties["PrivateTmp"] = "yes"

--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -288,6 +288,9 @@ class SystemdSpawner(Spawner):
             else:
                 working_dir = self._expand_user_vars(self.user_workingdir)
 
+        if self.cpu_weight:
+            env['CPU_WEIGHT'] = str(self.cpu_weight)                
+
         if self.isolate_tmp:
             properties["PrivateTmp"] = "yes"
 


### PR DESCRIPTION
This PR introduces a new configuration option `cpu_weight`. This sets the systemd property `CPUWeight`, which causes available CPU time to be sliced in proportion to each user's weight. 

This is a follow-up to PR #98.