### PR TITLE
Replace deprecated MemoryLimit with MemoryMax, remove fixme notes

### DIFF
--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -294,7 +294,7 @@ class SystemdSpawner(Spawner):
 
         if self.mem_limit is not None:
             properties["MemoryAccounting"] = "yes"
-            properties["MemoryLimit"] = self.mem_limit
+            properties["MemoryMax"] = self.mem_limit
 
         if self.cpu_limit is not None:
             # FIXME: Make sure that the kernel supports CONFIG_CFS_BANDWIDTH

--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -297,8 +297,15 @@ class SystemdSpawner(Spawner):
             properties["MemoryMax"] = self.mem_limit
 
         if self.cpu_limit is not None:
-            # FIXME: Make sure that the kernel supports CONFIG_CFS_BANDWIDTH
-            #        otherwise this doesn't have any effect.
+            # NOTE: The linux kernel must be started with the option
+            #       CONFIG_CFS_BANDWIDTH, otherwise CPUQuota doesn't have any
+            #       effect.
+            #
+            #       This can be checked with the check-kernel.bash script in
+            #       this git repository.
+            #
+            #       ref: https://github.com/systemd/systemd/blob/v245/README#L35
+            #
             properties["CPUAccounting"] = "yes"
             properties["CPUQuota"] = f"{int(self.cpu_limit * 100)}%"
 

--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -297,7 +297,7 @@ class SystemdSpawner(Spawner):
             properties["MemoryMax"] = self.mem_limit
 
         if self.cpu_limit is not None:
-            # NOTE: The linux kernel must be started with the option
+            # NOTE: The linux kernel must be compiled with the configuration option
             #       CONFIG_CFS_BANDWIDTH, otherwise CPUQuota doesn't have any
             #       effect.
             #

--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -293,12 +293,10 @@ class SystemdSpawner(Spawner):
         env["SHELL"] = self.default_shell
 
         if self.mem_limit is not None:
-            # FIXME: Detect & use proper properties for v1 vs v2 cgroups
             properties["MemoryAccounting"] = "yes"
             properties["MemoryLimit"] = self.mem_limit
 
         if self.cpu_limit is not None:
-            # FIXME: Detect & use proper properties for v1 vs v2 cgroups
             # FIXME: Make sure that the kernel supports CONFIG_CFS_BANDWIDTH
             #        otherwise this doesn't have any effect.
             properties["CPUAccounting"] = "yes"


### PR DESCRIPTION
Closes #126 where I did an investigation related to the removed fixme notes.

This change should not be breaking because MemoryMax replaces MemoryLimit according to docs, and has been documented to do that since v243 at least. See #126 for investigative notes about that.