### PR TITLE
ensure executable paths are absolute

### DIFF
--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -149,7 +149,6 @@ async def start_transient_service(
     # as any other Spawner would behave
     if not os.path.isabs(cmd[0]):
         path = os.getenv("PATH", os.defpath)
-        path = (environment_variables or {}).get("PATH")
         if environment_variables and "PATH" in environment_variables:
             path = environment_variables["PATH"]
         exe = cmd[0]

--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -144,9 +144,9 @@ async def start_transient_service(
         )
         run_cmd.append(f"--property=EnvironmentFile={environment_file}")
 
-    # make sure cmd[0] is absolute, which is a requirement of systemd-run
-    # if it's relative, resolve it with Spawner's $PATH,
-    # as any other Spawner would behave
+    # make sure cmd[0] is absolute, taking $PATH into account.
+    # systemd-run does not use the unit's $PATH environment
+    # to resolve relative paths.
     if not os.path.isabs(cmd[0]):
         path = os.getenv("PATH", os.defpath)
         if environment_variables and "PATH" in environment_variables:

--- a/systemdspawner/systemd.py
+++ b/systemdspawner/systemd.py
@@ -148,9 +148,14 @@ async def start_transient_service(
     # systemd-run does not use the unit's $PATH environment
     # to resolve relative paths.
     if not os.path.isabs(cmd[0]):
-        path = os.getenv("PATH", os.defpath)
         if environment_variables and "PATH" in environment_variables:
+            # if unit specifies a $PATH, use it
             path = environment_variables["PATH"]
+        else:
+            # search current process $PATH by default.
+            # this is the default behavior of shutil.which(path=None)
+            # but we still need the value for the error message
+            path = os.getenv("PATH", os.defpath)
         exe = cmd[0]
         abs_exe = shutil.which(exe, path=path)
         if not abs_exe:

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -126,6 +126,26 @@ async def test_workdir():
             assert text == d
 
 
+async def test_executable_path():
+    unit_name = "systemdspawner-unittest-" + str(time.time())
+    _, env_filename = tempfile.mkstemp()
+    with tempfile.TemporaryDirectory() as d:
+        await systemd.start_transient_service(
+            unit_name,
+            ["bash"],
+            ["-c", f"pwd > {d}/pwd"],
+            working_dir=d,
+            environment_variables={"PATH": os.environ["PATH"]},
+        )
+
+        # Wait a tiny bit for the systemd unit to complete running
+        await asyncio.sleep(0.1)
+
+        with open(os.path.join(d, "pwd")) as f:
+            text = f.read().strip()
+            assert text == d
+
+
 async def test_slice():
     unit_name = "systemdspawner-unittest-" + str(time.time())
     _, env_filename = tempfile.mkstemp()


### PR DESCRIPTION
systemd requires absolute paths for executables in order to resolve as expected.

Relative path executables do not take $PATH env into account when resolving the executable, only after launching the process, so `systemd-run bash -c exe` works, while just `systemd-run exe`  will not.

The default executable for a Spawner is the relative `jupyterhub-singleuser`, assuming  $PATH will be resolved.

Fixes the failure in https://github.com/jupyterhub/the-littlest-jupyterhub/pull/915