### PR TITLE
Stop assuming PATH env is defined when extra_paths is set, and then initialize to os.defpath

### DIFF
--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -285,9 +285,9 @@ class SystemdSpawner(Spawner):
 
         if self.extra_paths:
             new_path_list = [self._expand_user_vars(p) for p in self.extra_paths]
-            current_path = env.get("PATH")
-            if current_path:
-                new_path_list.append(current_path)
+            current_or_default_path = env.get("PATH", os.defpath)
+            if current_or_default_path:
+                new_path_list.append(current_or_default_path)
             env["PATH"] = ":".join(new_path_list)
 
         env["SHELL"] = self.default_shell

--- a/systemdspawner/systemdspawner.py
+++ b/systemdspawner/systemdspawner.py
@@ -284,12 +284,11 @@ class SystemdSpawner(Spawner):
             properties["PrivateDevices"] = "yes"
 
         if self.extra_paths:
-            env["PATH"] = "{extrapath}:{curpath}".format(
-                curpath=env["PATH"],
-                extrapath=":".join(
-                    [self._expand_user_vars(p) for p in self.extra_paths]
-                ),
-            )
+            new_path_list = [self._expand_user_vars(p) for p in self.extra_paths]
+            current_path = env.get("PATH")
+            if current_path:
+                new_path_list.append(current_path)
+            env["PATH"] = ":".join(new_path_list)
 
         env["SHELL"] = self.default_shell
 


### PR DESCRIPTION
I'm not sure if this is sufficient to resolve issues with using `extra_paths` together with jupyterhub 5.2.0 where `env_keep` doesn't include `PATH` in the Spawner base class any more, but it should probably be an incremental improvement no matter what.

See [debugging notes](https://github.com/jupyterhub/the-littlest-jupyterhub/pull/1008) in the littlest jupyterhub distribution when trying to upgrade jupyterhub from 5.1.0 to 5.2.0.

I've not added a test for `extra_paths` in this project, but it gets tested via tljh though, and via https://github.com/jupyterhub/the-littlest-jupyterhub/pull/1008 I can see that this made a positive difference making tests pass where they previously failed.